### PR TITLE
Add more languages; remove "Psiphon" string so it's not translated

### DIFF
--- a/_locales/am/messages.json
+++ b/_locales/am/messages.json
@@ -116,7 +116,7 @@
         "description": "Section heading for FAQ entries that don't fit in any other category."
     },
     "faq-authentic-windows-image-alt": {
-        "message": "The flow of dialog boxes required to find the certificate thumbprint for Psiphon for Windows",
+        "message": "የ Psiphon ለ Windows ማረጋገጫ ጣት አሻራ ለማግኘት የሚያስፈልገው የውይይት ሳጥኖች ፍሰት ",
         "description": "alt text for an image"
     },
     "faq-authentic-windows-question": {
@@ -188,7 +188,7 @@
         "description": "Part of the answer to the FAQ question 'How do I enable Android “Sideloading”?'"
     },
     "faq-android-enable-sideloading-image-alt": {
-        "message": "Screenshot of the Android security setting that allows installation of non-Play Store apps",
+        "message": "የ Play መደብር ያልሆኑ መተግበሪያዎችን መጫን የሚፈቅድ የ Android ደህንነት ቅንብር ቅጽበታዊ ገጽ እይታ",
         "description": "alt text for an image"
     },
     "faq-windows-xp-eol-question": {
@@ -196,7 +196,7 @@
         "description": "FAQ question."
     },
     "faq-windows-xp-eol-answer-para-1": {
-        "message": "As of December 2019, Psiphon does not support Windows XP or Vista. A legacy build <a href=\"https://psiphon.s3.amazonaws.com/legacy/psiphon3-legacy.exe\">is available for download</a> that will work on those platforms for the foreseeable future, but users are strongly encouraged to upgrade to a recent version of Windows.",
+        "message": "ከ ዲሴምበር 2019 (ጎርጎሮሳዊ አቆጣጠር) Psiphon Windows XP እና Vistaን አይደግፍም። ለመጪዎቹ ግዜያት የሚያገለግል ቅርስ ሥሪት <a href=\"https://psiphon.s3.amazonaws.com/legacy/psiphon3-legacy.exe\">ማውረድ ይቻላል።</a> ነገር ግን ተጠቃሚዎች  የቅርብ ግዜ የWindows ሥሪት\nእንዲጠቀሙ ይመከራል። ",
         "description": "FAQ answer to the question 'Does Psiphon for Windows work on Windows XP or Vista?'"
     },
     "faq-information-collected-answer-redirect": {
@@ -316,7 +316,7 @@
         "description": "FAQ question"
     },
     "faq-clear-windows-data-answer-para-1": {
-        "message": "Psiphon for Windows stores some data locally under the user's profile. It is located at a path like <code>C:\\Users\\YourName\\AppData\\Roaming\\Psiphon3</code>; or, more generally, <code>%APPDATA%\\Psiphon3</code>. You can delete the local data by going to that path in Windows Explorer and deleting it, or entering this command at a command prompt: <code>rmdir /s \"%APPDATA%\\Psiphon3\"</code>.",
+        "message": "Psiphon ለWindows የተወሰኑ መረጃዎችን በተጠቃሚው መገለጫ ስር በአካባቢው ያከማቻል ፡፡ እሱም እንደ <code>C፡ \\ ተጠቃሚዎች\\ስምዎት\\AppData\\Roaming\\Psiphon3</code> ያለ ባለበት መንገድ ይገኛል ፡፡ ወይም ፣ በአጠቃላይ ፣ <code>%APPDATA% \\ Psiphon3</code>። Windows ኤክስፕሎረር ውስጥ ወዳለው ዱካ በመሄድ እና በመሰረዝ አካባቢያዊውን ውሂብ መሰረዝ ይችላሉ ወይም በcommand prompt ውስጥ ያስገቡ:- <code>rmdir / s \"% APPDATA% \\ Psiphon3\"</code>።",
         "description": "FAQ answer to the question 'How do I clear Psiphon for Windows' local data?'"
     },
     "faq-proxy-all-question": {
@@ -332,7 +332,7 @@
         "description": ""
     },
     "faq-proxy-all-ios-browser-answer-para-1": {
-        "message": "Psiphon Browser for iOS is a browser-only application and so will only tunnel data that is loaded in the app itself, and will not tunnel your other apps (like your Facebook or Twitter apps) through the Psiphon network. So, for example, if you wanted to use the Psiphon network to access your Facebook account, you would use Psiphon Browser to go the Facebook website. If you were to open your Facebook app, it would use your direct internet connection, and would not be tunneled through the Psiphon network.",
+        "message": "Psiphon አሳሽ ለ iOS የአሳሽ-ብቻ መተግበሪያ ነው ፣ እና እንዲሁ በመተግበሪያው ውስጥ የተጫነውን ቦይ ብቻ ነው እንዲሁም ሌሎች መተግበሪያዎችዎን (እንደ Facebook እና Twitter መተግበሪያዎች) በፓሲሶን አውታረ መረብ በኩል አያስተካክለውም። ስለዚህ ፣ ለምሳሌ የፌስቡክ አካውንትዎን ለመድረስ የፒፊሶን አውታረ መረብን ለመጠቀም ከፈለጉ ወደ ፌስቡክ ድርጣቢያ ለመሄድ Psiphon Browser ን ይጠቀማሉ። የፌስቡክ መተግበሪያዎን የሚከፍቱ ከሆነ ቀጥታ የበይነመረብ ግንኙነትዎን የሚጠቀም ሲሆን በፒፊሶን አውታረመረብ በኩል አይስተካከልም።",
         "description": ""
     },
     "faq-browser-compatibility-question": {
@@ -348,7 +348,7 @@
         "description": "FAQ question. Note that 'port' is referring to network ports."
     },
     "faq-port-restrictions-answer-para-1": {
-        "message": "Outbound connections via the Psiphon network can only be made to a restricted set of server ports including: <code>53, 80, 443, 465, 587, 993, 995, 8000, 8001, 8080</code>. See <a href=\"https://groups.google.com/group/psiphon3/browse_thread/thread/8a7f3c42c5dd89e1\">this discussion</a> for more information. Mail clients cannot establish outbound connections on port 25. See <a href=\"https://groups.google.com/group/psiphon3/browse_thread/thread/2ef3a0af447ccd64\">this discussion</a> for more information.",
+        "message": "በPsiphon አውታረ መረብ በኩል ወደ ውጭ የሚደረጉ ግንኙነቶች ለየተገደቡ የአገልጋይ ወደቦች ስብስብ ብቻ ሊደረጉ የሚችሉት:- <code>53 ፣ 80 ፣ 443 ፣ 465 ፣ 587 ፣ 993 ፣ 995 ፣ 8000 ፣ 8001 ፣ 8080</code>። <a href=\"https://groups.google.com/group/psiphon3/browse_thread/thread/8a7f3c42c5dd89e1\">ይህንን ውይይት</a> ለተጨማሪ መረጃ ይመልከቱ ፡፡ የደብዳቤ ደንበኞች ወደብ 25 ላይ የወጪ ግንኙነቶች መመስረት አይችሉም ፡፡ ለተጨማሪ መረጃ <a href=\"https://groups.google.com/group/psiphon3/browse_thread/thread/2ef3a0af447ccd64\">ይህንን ውይይት</a> ይመልከቱ ፡፡",
         "description": "FAQ answer to the question 'Are there any port restrictions when using Psiphon?'"
     },
     "faq-mail-apps-ports-question": {
@@ -472,7 +472,7 @@
         "description": ""
     },
     "faq-isp-traffic-answer-para-1": {
-        "message": "All data that goes through Psiphon is encrypted. This means that your ISP cannot see the content of your Internet traffic: web pages you browse, your chat messages, your uploads, etc.",
+        "message": "በPsiphon በኩል የሚያልፍ ሁሉም ውሂብ የተመሰጠረ ነው። ይህ ማለት የእርስዎ አይኤስፒ የበይነመረብ ትራፊክዎን ይዘት ማየት አይችልም ማለት ነው-እርስዎ የሚያሰቧቸው ድረ ገጾች ፣ የውይይት መልእክቶችዎ ፣ ሰቀላዎችዎ ወዘተ ፡፡",
         "description": ""
     },
     "faq-isp-traffic-answer-para-2": {
@@ -500,11 +500,11 @@
         "description": "This is the first paragraph of a FAQ answer. Previously, users with old Android devices (before Android version 4.0, also known as Ice Cream Sandwich) could still tunnel the whole device if the device was rooted. This functionality was removed in December of 2015. This question/answer tells them about that and what they can do."
     },
     "faq-refund-question": {
-        "message": "How do I get a refund for a subscription, purchase of PsiCash, or other purchase?",
+        "message": "የደንበኝነት ምዝገባ፣ የ PsiCash ግዢ ወይም ሌላ ግዢ ከተሰረዘ እንዴት ገንዘቤን ማስመለስ እችላለሁ?",
         "description": "This is an FAQ question. This is for refunds made with money to purchase subscriptions, PsiCash, etc. 'Puchase of PsiCash' means buying PsiCash credit with real money."
     },
     "faq-refund-answer-para-1": {
-        "message": "<strong>Android:</strong> If it has been less than 48 hours since you made the purchase, you can <a href=\"https://support.google.com/googleplay/answer/7205930\" target=\"_blank\">get a refund through the Play Store</a>. After 48 hours, email us at <a href=\"mailto:refund+android@psiphon.ca?subject=Refund%20request&body=Name%3A%0AEmail%3A%0APurchase%20Date%3A%0AItem%3A%0AAmount%3A%0AReason%3A%0APlatform%3A%20Android\">refund+android@psiphon.ca</a>. Please include your name, the email address of your Play Store account, the date of the purchase, what was purchased, the amount of the purchase, and the reason you are requesting the refund.",
+        "message": "<strong>Android:-</strong>ግዢውን ከፈጸሙት ከ 48 ሰዓታት በታች ከሆነ <a href=\"https://support.google.com/googleplay/answer/7205930\" target=\"_blank\">በ Play መደብር በኩል ተመላሽ ገንዘብ ሊያገኙ ይችላሉ</a>። ከ 48 ሰዓታት በኋላ በኢሜል ይላኩልን <a href=\"mailto:refund+android@psiphon.ca?subject=Refund%20request&body=Name%3A%0AEmail%3A%0APurchase%20Date%3A%0AItem%3A%0AAmount%3A%0AReason%3A%0APlatform%3A%20Android\">በ2refund+windows@psiphon.ca2</a>። እባክዎትን ግዢውን በፈጸሙበት ግዜ የተጠቀሙትን ስምዎን ፣ ኢሜይልዎን እና ስልክ ቁጥርዎን ፤ ግዢው የተፈጸመበት ቀን ፣ የተገዛውን ነገር ፣ የግዢው መጠን እንዲሁም የገንዘብ ምላሽ የጠየቁበት ምክንያት።",
         "description": "This is the first paragraph of an FAQ answer."
     },
     "faq-refund-answer-para-2": {
@@ -512,7 +512,7 @@
         "description": "This is the second paragraph of an FAQ answer."
     },
     "faq-refund-answer-para-3": {
-        "message": "<strong>Windows:</strong> Email us at <a href=\"mailto:refund+windows@psiphon.ca?subject=Refund%20request&body=Name%3A%0AEmail%2FPhone%3A%0APurchase%20Date%3A%0AItem%3A%0AAmount%3A%0AReason%3A%0APlatform%3A%20Windows\">refund+windows@psiphon.ca</a>. Please include your name, the email address or phone number used at the time of purchase, the date of the purchase, what was purchased, the amount of the purchase, and the reason you are requesting the refund.",
+        "message": "<strong>Windows:-</strong> ኢሜይል ያርጉን በ<a href=\"mailto:refund+windows@psiphon.ca?subject=Refund%20request&body=Name%3A%0AEmail%2FPhone%3A%0APurchase%20Date%3A%0AItem%3A%0AAmount%3A%0AReason%3A%0APlatform%3A%20Windows\">refund+windows@psiphon.ca</a>። እባክዎትን ግዢውን በፈጸሙበት ግዜ  የተጠቀሙትን ስምዎን ፣ ኢሜይልዎን እና ስልክ ቁጥርዎን ፤ ግዢው የተፈጸመበት ቀን ፣ የተገዛውን ነገር ፣ የግዢው መጠን እንዲሁም የገንዘብ ምላሽ የጠየቁበት ምክንያት።",
         "description": "This is the third paragraph of an FAQ answer."
     },
     "faq-refund-answer-para-4": {
@@ -616,7 +616,7 @@
         "description": "text for link to Psiphon for Windows download"
     },
     "download-windows-direct-description-v2": {
-        "message": "Works on Windows 7, Windows 8 (desktop), and Windows 10.<br>(A legacy build for <a href=\"./faq.html#windows-xp-eol\">Windows XP and Vista</a> is available.)",
+        "message": "በWindows 7 ፣ በWindows 8 (ዴስክቶፕ) እና በWindows 10 ላይ ይሰራል።",
         "description": "Descriptive text on the download page indicating what versions of Windows Psiphon does and does not support. Windows XP and Vista are no longer supported, but there is an old (legacy) build available for download."
     },
     "download-android-direct": {
@@ -648,15 +648,15 @@
         "description": "Text for link to Psiphon for iOS in the Apple App Store. This is the 'whole device' version of Psiphon, as distinct from the 'Psiphon Browser' app."
     },
     "download-ios-appstore-psiphon-vpn-description": {
-        "message": "All of the apps on your iPhone or iPad will access the Internet through the Psiphon network. Available for iOS 10.2 and higher.",
+        "message": "በእርስዎ iPhone ወይም በ iPad ላይ ያሉት ሁሉም መተግበሪያዎች በፓሚሶን አውታረ መረብ በኩል በይነመረብን ይጠቀማሉ። ለ iOS 10.2 እና ከዚያ በላይ ይገኛል።",
         "description": "Description of Psiphon for iOS on the download page. Partly intended to distinguish 'Psiphon for iOS' from 'Psiphon Browser for iOS'."
     },
     "download-ios-appstore-psiphon-browser": {
-        "message": "<strong>Psiphon Browser for iOS</strong> in the Apple App Store",
+        "message": "<strong>Psiphon አሳሽ ለ iOS</strong> የአፕል መተግበሪያ መደብር ውስጥ",
         "description": "Text for link to Psiphon Browser for iOS in the Apple App Store. This app is distinct from the 'Psiphon for iOS' app that tunnels the whole device."
     },
     "download-ios-appstore-psiphon-browser-description": {
-        "message": "Access your favorite web sites and services through the Psiphon network with our easy-to-use web browser. Available for iOS 8 and higher.",
+        "message": "በአጠቃቀም ቀላል በሆነ የድር አሳችን በመጠቀም ተወዳጅ የድረ ገጾችን እና አገልግሎቶችን በፓሲሶን አውታረ መረብ በኩል ይድረሱባቸው። ለ iOS 8 እና ከዚያ በላይ ይገኛል።",
         "description": "Description of Psiphon Browser for iOS on the download page. Partly intended to distinguish 'Psiphon Browser for iOS' from 'Psiphon for iOS'."
     },
     "download-store-head": {
@@ -700,11 +700,11 @@
         "description": ""
     },
     "user-guide-android-ui-status-image-alt": {
-        "message": "Screenshot showing the Psiphon for Android status panel",
+        "message": "Psiphon ለ Android ሁኔታ ፓነልን የሚያሳየው ቅጽበታዊ ገጽ እይታ",
         "description": "alt text for an image"
     },
     "user-guide-android-image-3-alt": {
-        "message": "Screenshot showing the Psiphon for Android web browser",
+        "message": "Psiphon ለ Android (አንድሮይድ) የድር ማሰሻን የሚያሳይ ቅጽበታዊ ገጽ እይታ",
         "description": "alt text for an image"
     },
     "user-guide-android-image-3-annotation-1": {
@@ -748,7 +748,7 @@
         "description": "annotation for an image of the Psiphon's status view, pointing to the currently running Psiphon version number"
     },
     "user-guide-android-ui-logs-image-alt": {
-        "message": "Screenshot showing the Psiphon for Android logs panel",
+        "message": "Psiphon ለ Android (አንድሮይድ) ምዝግብ  ፓነል የሚያሳይ ቅጽበታዊ የገጽ እይታ",
         "description": "alt text for an image"
     },
     "user-guide-android-ui-logs-image-annotation-1": {
@@ -812,7 +812,7 @@
         "description": ""
     },
     "user-guide-windows-image-1-alt": {
-        "message": "Screenshot showing the Windows security warning for the Psiphon executable",
+        "message": "የWindows Psiphon ተፈጻሚ የደህንነት ማስጠንቀቂያ የሚያሳይ ምስል ",
         "description": "alt text for an image"
     },
     "user-guide-windows-image-2-alt": {
@@ -820,7 +820,7 @@
         "description": "alt text for an image"
     },
     "user-guide-windows-image-3-alt": {
-        "message": "Screenshot showing Psiphon connected on Windows",
+        "message": "በWindows ላይ Psiphin እንደተገናኘ የሚያሳይ ምስል ",
         "description": "alt text for an image"
     },
     "blog-index-title": {
@@ -944,7 +944,7 @@
         "description": ""
     },
     "license-statement-of-limitations-of-liability-para": {
-        "message": "The Psiphon service is provided “as is” and without warranty or expressed or implied liability of any kind. Psiphon disclaims all warranties and liabilities associated with the use of this service, including personal injury, or any incidental, special, indirect or consequential personal or commercial damages whatsoever, including loss of data and business interruption.",
+        "message": "የፒፎንቶን አገልግሎት “እንደዚያው” ነው ያለ ዋስትናም ሆነ ያለ አንዳች መግለጫ ወይም በተዘዋዋሪ ሀላፊነት የተሰጠው ነው ፡፡ Psiphon የግል ጉዳትን ጨምሮ ወይም ማንኛውንም ክስተት ፣ ልዩ ፣ ቀጥተኛ ያልሆነ ወይም ተከሳሽ የግል ወይም የንግድ ጉዳትን ጨምሮ ፣ ከዚህ አገልግሎት አጠቃቀም ጋር የተገናኙትን ሁሉንም ዋስትናዎች እና ግዴታዎች ይተወዋል።",
         "description": ""
     },
     "license-termination-terms-of-service-violations-header": {
@@ -964,15 +964,15 @@
         "description": "Subsection header on the License page. 'PsiCash' should not be translated or transliterated."
     },
     "license-psicash-item-1": {
-        "message": "If there is no PsiCash activity on your device for one year, then Psiphon reserves the right to cancel your PsiCash.",
+        "message": "ለአንድ ዓመት ያህል በመሣሪያዎ ላይ የPsiCash እንቅስቃሴ ከሌለ ፒሲሶን የእርስዎን PsiCash የመሰረዝ መብቱ የተጠበቀ ነው ፡፡",
         "description": "List item under the 'Use of PsiCash' subsection of the License page. The essence of this item is that if a user doesn't earn or spend PsiCash for a year, then Psiphon might delete it. 'PsiCash' should not be translated or transliterated."
     },
     "license-psicash-item-2": {
-        "message": "If you lose track of your PsiCash, for example by losing your device, then you acknowledge that Psiphon will not be able to correct this mistake and restore your PsiCash.",
+        "message": "ለምሳሌ የፒሲሲሽ (PsiCash) ዱካዎ ከጠፋብዎ ለምሳሌ መሳሪያዎን በጠፋብዎ Psiphon ይህንን ስህተት ለማስተካከል እና የእርስዎን PsiCash ወደነበረበት መመለስ እንደማይችል እውቅና ይሰጣሉ።",
         "description": "List item under the 'Use of PsiCash' subsection of the License page. The essence of this item is that Psiphon won't (and can't) restore a user's PsiCash if the user loses the device that that PsiCash is associated with. 'PsiCash' should not be translated or transliterated."
     },
     "license-psicash-item-3": {
-        "message": "Psiphon reserves the right to change the rewards exchangeable for PsiCash at any time.",
+        "message": "Psiphon በማንኛውም ጊዜ ለPsiCash የሚለወጡትን ሽልማቶች የመቀየር መብቱ የተጠበቀ ነው ፡፡",
         "description": "List item under the 'Use of PsiCash' subsection of the License page. The essence of this item is that Psiphon may change what things -- like Speed Boost -- cost in PsiCash. 'PsiCash' should not be translated or transliterated."
     },
     "about-who-we-are-head": {
@@ -1020,7 +1020,7 @@
         "description": ""
     },
     "about-who-we-are-partners-para-1": {
-        "message": "Psiphon works closely with various groups to provide support and advice to people using Psiphon wherever they are. We have translations for our software in dozens of languages, and are adding more to our products through <a href=\"https://www.transifex.com/projects/p/Psiphon3/\" target=\"_blank\">Transifex</a>, with the help of the <a href=\"https://www.localizationlab.org/\" target=\"_blank\">Localization Lab</a>.",
+        "message": "Psiphon በሚኖሩበት ቦታ ሁሉ Psiphon ን ለሚጠቀሙ ሰዎች ድጋፍ እና ምክር ለመስጠት ከተለያዩ ቡድኖች ጋር በቅርብ ይሠራል ፡፡ ለሶፍትዌራችን በብዙዎች ቋንቋዎች ትርጉሞች አለን ፣ እና በትርጉም ልኬታችን እገዛ በ <a href=\"https://www.transifex.com/projects/p/Psiphon3/\" target=\"_blank\">Transifex</a> በኩል ወደ ምርታችን የበለጠ እየጨመርን ነው።",
         "description": "There are more than 20 languages currently supported, so if your language has a better fit than 'dozens', please use it. You can also just use something more generic, like 'many'."
     },
     "about-contact-head": {
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon ምንጨ ክፍት ነው።",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "የPsiphon ደምበኞች የሚከተሉትን ክፍት የመረጃ ክፍሎች ይጠቀማሉ፡-",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows፡- ",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android፡-",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon ክፍት ምንጭ ሶፍትዌር  ነው። ኮዳችንን GitHub ላይ  ማግኘት ይችላሉ።",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "አውርድ ",
@@ -1251,6 +1239,22 @@
         "message": "ያን የምናደርገው መቼ ነው ",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "አዘምን ",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "ምን ተፈጠረ",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "ተጽዕኖ",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "ውሳኔ",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "ምን አይነት የተጠቃሚ ዳታ ይሰበሰባል ",
         "description": ""
@@ -1320,32 +1324,52 @@
         "description": "Title for a privacy bulletin"
     },
     "privacy-bulletin-entry-3-what-doing": {
-        "message": "We are updating our <a href=\"privacy.html\">Privacy Policy</a>. We are changing the retention period of User Activity Data from 60 days to 90 days. We also expanded the information about Privacy Bulletins. For the exact changes, see the <a target=\"_blank\" href=\"https://github.com/Psiphon-Inc/psiphon-website/commit/3327279e65aa5929ea50379f74a85aab3a69c8bf\">GitHub commit</a>.",
+        "message": "<a href=\"privacy.html\">የግላዊነት ፖሊሲያችንን</a> እያዘመንነን ነው። የተጠቃሚን እንቅስቃሴ የመያዝ ጊዜ ከ 60 ቀናት እስከ 90 ቀናት እንቀይራለን ፡፡ እንዲሁም ስለ ግላዊነት ማስታወቂያዎች ይለውን መረጃ ጨምረናል። ለትክክለኛው ለውጦች የ<a target=\"_blank\" href=\"https://github.com/Psiphon-Inc/psiphon-website/commit/3327279e65aa5929ea50379f74a85aab3a69c8bf\"> GitHub Commitን</a> ይመልከቱ።",
         "description": "A section of a privacy bulletin, indicating what is occurring that necessitates the bulletin"
     },
     "privacy-bulletin-entry-3-why-doing": {
-        "message": "To ensure the Privacy Policy accurately reflects our data practices.",
+        "message": "የግላዊነት መምሪያ በትክክል የውሂብ ትግበራችንን እንደሚያንጸባርቅ ለማረጋገጥ።",
         "description": "A section of a privacy bulletin, giving the reason for the change that necessitates the bulletin"
     },
     "privacy-bulletin-entry-3-when-doing": {
-        "message": "This will be in effect on 2019-12-12T00:00Z.",
+        "message": "ይህ ከ 2019-12-12T00:00Z ጀምሮ ተግባራዊ ሆኗል። ",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
     },
     "privacy-bulletin-entry-4-title": {
-        "message": "2019-12-11: Temporary data retention extension",
+        "message": "2019-12-11፦ ዘላቂነት የሌለው የውሂብ ይዞታ ማከያ",
         "description": "Title for a privacy bulletin"
     },
     "privacy-bulletin-entry-4-what-doing": {
-        "message": "We are temporarily halting User Activity Data pruning, effectively extending the data retention period.",
+        "message": "የውሂብ ማቆያ ጊዜያችንን ውጤታማ በሆነ መንገድ እናራዝማለን ፣ የተጠቃሚ እንቅስቃሴን የመቁረጥ ጊዜን ለጊዜው እናቆማለን።",
         "description": "A section of a privacy bulletin, indicating what is occurring that necessitates the bulletin"
     },
     "privacy-bulletin-entry-4-why-doing": {
-        "message": "We need to keep granular activity data longer to give us time to analyze recent censorship events.",
+        "message": "የቅርብ ጊዜ ሳንሱር ዝግጅቶችን ለመተንተን ጊዜ ለመስጠት ጊዜን ለመስጠት የታሪካዊ እንቅስቃሴን መረጃ ረዘም ላለ ጊዜ ማቆየት አለብን።",
         "description": "A section of a privacy bulletin, giving the reason for the change that necessitates the bulletin"
     },
     "privacy-bulletin-entry-4-when-doing": {
-        "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
+        "message": "ይህ ተፈጻሚ የሚሆነው ከ2019-12-12T00:00Z (ጎርጎሮሳዊ አቆጣጠር)። ተፈጻሚ የሚሆነው ለአንድ ወር ነው። ከዛ በላይ ከተራዘመ ይህን ማስታወቂያ እናዘምነዋለን።",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "የተጠቃሚ እንቅስቃሴ ውሂብ ይዘት በ 2020-04-10 (ጎ.አ.) ወደ መደበኛ ተመልሷል።",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19 (ጎርጎሮሳዎ አቆጣጠር) ፦ የግላዊነት exception:- በስህተት የተጠቅሚን IP ይዞ ማስቀመጥ",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "ድር ጣቢያዎችን ፣ የደንበኛ መተግበሪያዎችን እና የርቀት አገልጋዮችን ዝርዝር ለማስተናገድ AWS S3 ን እንጠቀማለን ፡፡ እ.ኤ.አ. ከሰኔ 2015 ጀምሮ ለአብዛኛዎቹ የ S3 ሀብቶች ምዝገባ እንደነቃ አወቅን። እነዚህ ምዝግብ ማስታወሻዎች እነዚህን ሀብቶች የደረሱ የተጠቃሚዎች አይፒ አድራሻዎችን ያካትታሉ።",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "በማንኛውም ምዝግብ ማስታወሻዎች በማንኛውም የውጭ አካል የተገኘ መሆኑን የሚጠቁም ምንም ነገር የለንም ፣ ስለዚህ ይህ የተጠቃሚው መብት ጥሰት አይደለም ፡፡ ሆኖም የግላዊነት ፖሊሲያችን ጥሰት ነው።",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "ለተጠቃሚ ተደራሽ ለሆኑ S3 ባልዲዎች ምዝግብ ማስታወሻ ቦዝኗል (ቦዝኗል) እና ሁሉም ምዝግብ ማስታወሻዎች ተሰርዘዋል ፡፡ ልዩ ሁኔታዎችን እና ጉዳዮችን ለመከታተል እና የ AWS ሀብት ቁጥጥርን ለመመርመር በአንድ ስርዓት ላይ እየሰራን ነው ፡፡",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "የግላዊነት ፖሊሲ ",
@@ -1384,15 +1408,15 @@
         "description": "Heading for a section in our privacy policy. The section description how we handle updates to the policy."
     },
     "privacy-bulletin-info-para-1": {
-        "message": "From time to time, Psiphon will add entries to our <a href=\"./privacy-bulletin.html\">Privacy Bulletin</a>. This will happen for two reasons:",
+        "message": "ከጊዜ ወደ ጊዜ ፣ Psiphon ግቤቶችን <a href=\"./privacy-bulletin.html\">በግላዊነት ማስታወቂያችን</a> ላይ ያክላል። ይህ በሁለት ምክንያት ይከሰታል-",
         "description": "Paragraph introducing a bullet list."
     },
     "privacy-bulletin-info-para-2-item-1": {
-        "message": "We modify the Privacy Policy. This can happen when new laws add different requirements, or if we start or stop using a third-party service. We will detail the changes made to the policy.",
+        "message": "የግላዊነት ፖሊሲውን እናሻሽለዋለን። አዲስ ህጎች የተለያዩ መስፈርቶችን ሲጨምሩ ፣ ወይም የሶስተኛ ወገን አገልግሎትን ከጀመርን ወይም ካቆምን ይህ ሊከሰት ይችላል ፡፡ በመመሪያው ላይ የተደረጉ ለውጦችን በዝርዝር እንገልጻለን።",
         "description": "A bullet list item following from 'This will happen for two reasons:'"
     },
     "privacy-bulletin-info-para-2-item-2": {
-        "message": "We temporarily deviate from our Privacy Policy by changing our information collection behaviour. This is typically done to resolve a problem with our service, or to give us more time to analyze our data relating to an interesting censorship event. We will describe the change, for example what was recorded, how long it was kept, and why.",
+        "message": "የመረጃ አሰባሰብ ባህርያችንን በመለወጥ ለጊዜው ከግላዊነት ፖሊሲያችን እንርቃለን። ይህ በተለምዶ የሚከናወነው በአገልግሎታችን ላይ ያለ ችግርን ለመፍታት ወይም ከአስደናቂ ሳንሱር ጋር የተገናኘን ውሂብን ለመተንተን የበለጠ ጊዜ ለመስጠት ነው። ለውጡን እንገልፃለን ፣ ለምሳሌ ምን እንደተመዘገበ ፣ ለምን ያህል ጊዜ እንደቆየ እና ለምን እንደ ሆነ እንገልፃለን።",
         "description": "A bullet list item following from 'This will happen for two reasons:'"
     },
     "faq-information-collected-question": {
@@ -1400,7 +1424,7 @@
         "description": "Heading for a section in our privacy policy."
     },
     "privacy-information-collected-client-ads-head": {
-        "message": "Psiphon Client Advertising Networks",
+        "message": "Psiphon ተገልጋይ የማስታወቂያ አውታረመረቦች",
         "description": "Sub-heading on the Privacy Policy page above the info about what user information is collected by the ads shown in the Psiphon client software"
     },
     "privacy-information-collected-client-advertising-networks-para-1": {
@@ -1424,7 +1448,7 @@
         "description": ""
     },
     "privacy-information-collected-websites-google-analytics-para-2": {
-        "message": "Google Analytics sets a permanent cookie in your web browser to identify you as a unique user the next time you visit the site, but this cookie cannot be used by anyone except Google, and the data collected cannot be altered or retrieved by services from other domains.",
+        "message": "Google ትንታኔዎች በሚቀጥለው ጊዜ ጣቢያውን ሲጎበኙ እርስዎን እንደ ልዩ ተጠቃሚ ለመለየት በእርስዎ Google አሳሽዎ ውስጥ ዘላቂ ኩኪ ያዘጋጃል ፣ ግን ይህ ኩኪ ከ Google በስተቀር በማንም ሰው ሊጠቀም አይችልም ፣ እና የተሰበሰበው መረጃ በሌሎች ጎራዎች አገልግሎቶች ሊቀየር ወይም ሊመለስ አይችልም። .",
         "description": ""
     },
     "privacy-information-collected-websites-google-analytics-para-3": {
@@ -1448,11 +1472,11 @@
         "description": ""
     },
     "faq-information-collected-answer-para-1": {
-        "message": "Psiphon runs many servers for many reasons. On those servers we collect the following data to monitor the health of the Psiphon system. It helps us to learn things like how well Psiphon is working, what propagation strategies are effective, and how users are obtaining the Psiphon client.",
+        "message": "Psiphon በብዙ ምክንያቶች ብዙ አገልጋዮችን ያካሂዳል። በእነዚያ ሰርቨር ላይ የፒፊሶን ስርዓት ጤናን ለመቆጣጠር የሚከተሉትን መረጃዎች እንሰበስባለን ፡፡ ፕፊሶን ምን ያህል እየሰራ እንደሆነ ፣ ምን ዓይነት የማሰራጨት ስልቶች ውጤታማ እንደሆኑ እና ተጠቃሚዎች እንዴት የፎምፎን ደንበኛውን እንደሚያገኙ ያሉ ነገሮችን ለመማር ይረዳናል።",
         "description": ""
     },
     "faq-information-collected-answer-para-2-item-1": {
-        "message": "Number of email requests to our automated responder",
+        "message": "ለራስሠር መላሻችን የተሰነዘሩ የኢሜይል ጥያቄዎች ቁጥር",
         "description": ""
     },
     "faq-information-collected-answer-para-2-item-2": {
@@ -1472,11 +1496,11 @@
         "description": ""
     },
     "faq-information-collected-answer-para-2-item-7": {
-        "message": "Amount of data transferred through the Psiphon system",
+        "message": "በPsiphon ሥርዓት የተላለፈ የውሂብ መጠን",
         "description": ""
     },
     "faq-information-collected-answer-para-2-item-9": {
-        "message": "Client platform (simplified operating system list; not a detailed browser user agent)",
+        "message": "የተገልጋይ መድረክ (የተቃለለ ሥርዓተ ክወና ዝርዝር እንጂ የተብራራ አሳሽ ተጠቃሚ ወኪል አይደለም)",
         "description": ""
     },
     "faq-information-collected-answer-para-3b": {
@@ -1484,15 +1508,15 @@
         "description": ""
     },
     "faq-information-collected-answer-para-4": {
-        "message": "Event logs include timestamps, region codes (country and city), and non-identifying attributes including sponsor ID (determined by which Psiphon client build is used), client version, and protocol type.",
+        "message": "የዝግጅት ምዝግቦች የጊዜ ማህተሞችን ፣ የክልል ኮዶች (ሀገር እና ከተማ) እና ስፖንሰር መታወቂያ (የፒምፎን ደንበኛ በሚጠቀሙበት ጊዜ) ፣ የደንበኛ ሥሪት እና የፕሮቶኮሉ ዓይነትን ጨምሮ የማይታወቁ ባህሪያትን ያጠቃልላል ፡፡",
         "description": ""
     },
     "faq-information-collected-answer-para-5": {
-        "message": "Any statistics shared with third parties are aggregated by date, sponsor, and region, to a sufficient coarseness that they are non-identifying.",
+        "message": "ከሶስተኛ ወገኖች ጋር የተጋሩ ማንኛውም አኃዛዊ መረጃዎች ቀንን ፣ ሰፋይን ፣ እና አካባቢን በማያወሳው በቂ የጠበቀ አንድነት አላቸው ፡፡",
         "description": ""
     },
     "privacy-information-collected-vpndata-head-v2": {
-        "message": "User Activity and VPN Data",
+        "message": "የተጠቃሚ እንቅስቃሴ እና የምናባዊ የግል አውታረ መረብ (ቪፒኤን) ውሂብ",
         "description": "Sub-heading on the Privacy Policy page for the section describing handling of user traffic data and activity statistics through the Psiphon VPN"
     },
     "privacy-information-collected-vpndata-whycare-subhead": {
@@ -1500,39 +1524,39 @@
         "description": "Sub-heading in the 'User Activity and VPN Data' section of the Privacy Policy page. The section describes why it's important for users to consider what a VPN does with their traffic data."
     },
     "privacy-information-collected-vpndata-whycare-para-1": {
-        "message": "When using a VPN or proxy you should be concerned about what the VPN provider can see in your data, collect from it, and do to it.",
+        "message": "VPN ወይም ተኪን ሲጠቀሙ የቪ.ፒ.ኤን አቅራቢ በውሂብዎ ውስጥ ሊያየው ስለሚችለው ነገር መጨነቅ አለብዎት ፣ ከእሱ ሊሰበስብ እና ሊያደርገው ይችላል።",
         "description": "Paragraph text in the 'Why should you care?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whycare-para-2": {
-        "message": "When you use a VPN, all data to and from your device goes through it. If you visit a website that uses unencrypted HTTP, all of that site's data is visible to the VPN. If you visit a website that uses encrypted HTTPS, the site content is encrypted, but some information about the site might be visible to the VPN. Other apps and services on your device will also transfer data that is encrypted or unencrypted. (Note that this is distinct from the encryption that all VPNs provide. Here we're only concerned with data that is or is not encrypted <em>inside</em> the VPN tunnel.)",
+        "message": "VPN ን ሲጠቀሙ ወደ መሳሪያዎ እና ከእሱ የሚመጣው ሁሉም ውሂብ በእሱ በኩል ያልፋል። የተመሰጠሩ ኤችቲቲፒአፕን የሚጠቀም ድር ጣቢያ ከጎበኙ ሁሉም የዚያ ጣቢያ ውሂብ ለ VPN ይታያል። የተመሰጠሩ ኤች ቲ ቲ ፒ ፒዎችን የሚጠቀም ድር ጣቢያ ከጎበኙ የጣቢያው ይዘት የተመሰጠረ ነው ፣ ግን ስለጣቢያው አንዳንድ መረጃዎች ለ VPN ይታያል። በመሣሪያዎ ላይ ያሉ ሌሎች መተግበሪያዎች እና አገልግሎቶች እንዲሁም የተመሰጠረ ወይም ያልተመሳጠረ ውሂብ ያስተላልፋሉ። (ይህ ሁሉም VPNs ከሚሰጥበት ምስጠራ የተለየ መሆኑን ልብ ይበሉ ፡፡ እዚህ የምንመለከተው በቪ.ፒ.ኤን. ቦይ <em>ውስጥ</em> ያልተመሰጠረ ወይም ያልተሰበረው መረጃ ብቻ ነው) ፡፡",
         "description": "Paragraph text in the 'Why should you care?' subsection of the 'User Activity and VPN Data' section of the Privacy page. '<em>' is an 'emphasis' (like italics) HTML tag, which can be used if it makes sense in your language."
     },
     "privacy-information-collected-vpndata-whycare-para-3": {
-        "message": "For unencrypted services, it is possible for a VPN provider to see, collect, and modify (e.g., injecting ads into) the contents of your data. For encrypted data, it is still possible for a VPN to collect metadata about sites visited or actions taken. You should also be concerned with your VPN provider sharing your data with third parties.",
+        "message": "ላልተመዘገቡ አገልግሎቶች ለ VPN አቅራቢ የውሂብዎን ይዘቶች ማየት ፣ መሰብሰብ እና ማሻሻል ይችላል (ለምሳሌ ፣ ማስታወቂያዎችን ወደ ውስጥ በማስገባት) ፡፡ ለተመሰጠረ መረጃ ፣ VPN ስለተጎበኙት ጣቢያዎች ወይም ስለተወሰ actionsቸው እርምጃዎች ዲበ ውሂብ ለመሰብሰብ አሁንም ይቻላል ፡፡ እንዲሁም ውሂብዎን ለሶስተኛ ወገኖች ሲያጋራ የቪ.ፒ.ኤን አቅራቢዎም ጥንቃቄ ማድረግ አለብዎት ፡፡",
         "description": "Paragraph text in the 'Why should you care?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whatdoespsiphonnotdowith-subhead": {
-        "message": "What does Psiphon <strong>NOT</strong> do with your data?",
+        "message": "Psiphon በውሂቦ ምን <strong>አያደርግም</strong>?",
         "description": "Sub-heading in the 'User Activity and VPN Data' section of the Privacy Policy page. The section describes what undesirable things Psiphon DOES NOT do with user data. '<strong>' is an HTML tag that makes text bold, which can be used if it makes sense in your language."
     },
     "privacy-information-collected-vpndata-whatdoespsiphonnotdowith-para-1": {
-        "message": "We DO NOT collect or store any VPN data that is not mentioned here.",
+        "message": "እዚህ ጋር ያልተጠቀሰ የምናባዊ የግል አውታረ መረብ (ቪፒኤን) ውሂብ አንሰበስብም፣ አናስቀምጥም።",
         "description": "Paragraph text in the 'What does Psiphon NOT do with your data?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whatdoespsiphonnotdowith-para-2": {
-        "message": "We DO NOT modify the contents of your VPN data.",
+        "message": "ምናባዊ የግል አውታረ መረብ (ቪፒኤን) ውሂብዎን ይዘት እንቀይርም።",
         "description": "Paragraph text in the 'What does Psiphon NOT do with your data?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whatdoespsiphonnotdowith-para-3": {
-        "message": "We DO NOT share any sensitive or user-specific data with third parties.",
+        "message": "እኛ ለሶስተኛ ወገን ",
         "description": "Paragraph text in the 'What does Psiphon NOT do with your data?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-kindsofdata-subhead": {
-        "message": "What kinds of user data does Psiphon collect?",
+        "message": "(Psiphon) የሚሰበስበው የተጠቃሚዎች መረጃ ምን አይነት ነው？ ",
         "description": "Sub-heading in the 'User Activity and VPN Data' section of the Privacy Policy page."
     },
     "privacy-information-collected-vpndata-kindsofdata-para-1": {
-        "message": "We will define some categories of data to help us talk about them in the context of Psiphon.",
+        "message": "በቪ.ፒ.ኤን. የመድረክ ተልእኮ በተሰጠን በድምጽ የተደነገገው የቪ.ፒ.ኤን. ለክብሩ የተሾሙ የክብር ዘብ ሹሞች ለዲቪዥን የመጠበቅ ሥነ ስርዓት",
         "description": "Paragraph text in the 'What kinds of user data does Psiphon collect?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-useractivity-subhead": {
@@ -1540,19 +1564,19 @@
         "description": "Sub-heading for the definition of 'User Activity Data' under the 'User Activity and VPN Data' section of the Privacy Policy page."
     },
     "privacy-information-collected-vpndata-useractivity-para-1": {
-        "message": "While a user's device is tunneled through Psiphon, we collect some information about how they're using it. We record what protocol Psiphon used to connect, how long the device was connected, how many bytes were transferred during the session, and what city, country, and ISP the connection came from. For some domains (but very few, and only popular ones) or server IP addresses (e.g., known malware servers) that are visited, we also record how many bytes were transferred to it. (But never full URLs or anything more sensitive. And only domains of general interest, not all domains.)",
+        "message": "የተጠቃሚው መሣሪያ በፓፊሶን በኩል እየተስተካከለ እያለ እንዴት እንደሚጠቀሙበት አንዳንድ መረጃዎችን እንሰበስባለን። Psiphon ለማገናኘት ምን ፕሮቶኮልን እንደተጠቀመ ፣ መሣሪያው ለምን ያህል ጊዜ እንደተገናኘ ፣ በክፍለ-ጊዜው ጊዜ ምን ያህል ባይቶች እንደተዛወሩ ፣ እና ግንኙነቱ ከየትኛው ከተማ ፣ ሀገር እና አይኤP እንደመጣ እንመዘግባለን ፡፡ ለአንዳንድ ጎራዎች (ግን በጣም ጥቂቶች ፣ እና ታዋቂዎች ብቻ) ወይም የጎበኙ የጎብኝዎች የአይፒ አድራሻ (ለምሳሌ ፣ የሚታወቁ ተንኮል-አዘል ዌር አገልጋዮች) ፣ ስንት ባይት ወደ እሱ እንደተላለፈ እንመዘግባለን ፡፡ (ግን በጭራሽ ሙሉ ዩ.አር.ኤል.ዎች ወይም የበለጠ ስሜት ሊጎድል የሚችል ነገር የለም ፡፡",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-useractivity-para-2": {
-        "message": "Geographical location and ISP info are derived from user IP addresses, which are then immediately discarded.",
+        "message": "መልክአ ምድራዊ አቀማመጥ እና የአይ.ፒ.አይ. መረጃ የተገኘው ከተጠቃሚ የአይፒ አድራሻዎች ነው ፣ ከዚያ ወዲያውኑ ይጣላሉ ፡፡",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-useractivity-para-3": {
-        "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
+        "message": "የተጠቃሚ እንቅስቃሴ ውሂብ ምሳሌ ሊሆን ይችላል በአንድ ጊዜ ከኒው ዮርክ ሲቲ የተገናኘ ተጠቃሚ Comcast ን በመጠቀም እና ከድምሩ 100 ሜባ  ከ <code>youtube.com</code> 300 ሜባ ያስተላልፋል ፡፡",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "የተጠቃሚ እንቅስቃሴን ውሂብ በጣም ሚስጥራዊነት ያለው የመረጃ ምድብ ነው የምንቆጥረው። እኛ በጭራሽ ፣ ይህንን ውሂብ መቼም ቢሆን ለሶስተኛ ወገን አናጋራም ፡፡ የተጠቃሚ እንቅስቃሴ እንቅስቃሴን ቢያንስ ለ 90 ቀናት እናቆያለን ፣ እናጠናለን ከዚያ በኋላ እንሰርዘዋለን። የዚያ ውሂብ ምትኬዎች ለተወሰነ ጊዜ ይቀመጣሉ።",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {
@@ -1560,15 +1584,15 @@
         "description": "Sub-heading for the definition of 'Aggregated Data' under the 'User Activity and VPN Data' section of the Privacy Policy page."
     },
     "privacy-information-collected-vpndata-aggdata-para-1": {
-        "message": "Data is “aggregated” by taking a lot of sensitive user activity data and combining it together to form coarse statistical data that is no longer specific to a user. After aggregation, the user activity data is deleted.",
+        "message": "ብዙ ስሱ የሆኑ የተጠቃሚ እንቅስቃሴ ውሂቦችን በመውሰድ እና በአንድ ላይ በማጣመር ለተጠቃሚው በቀጥታ የማይጠቅም ጠንካራ የስታቲስቲካዊ ውሂብን ለማዋሃድ ውሂቡ “ተደባልቋል። ከጠቅላላው በኋላ የተጠቃሚው እንቅስቃሴ እንቅስቃሴ ይሰረዛል።",
         "description": "Paragraph text in the 'Aggregated Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-para-2": {
-        "message": "An example of aggregated data might be: On a particular day, 250 people connected from New York City using Comcast, and transferred 200GB from <code>youtube.com</code> and 500GB in total.",
+        "message": "የተጠቃለለ መረጃ ምሳሌ የሚከተለው ሊሆን ይችላል-በአንድ ቀን ፣ Comcast ን በመጠቀም ከኒው ዮርክ ሲቲ የተገናኙ 250 ሰዎች እና በአጠቃላይ 200 ጊ.ባ. ከ<code>youtube.com</code> ባጠቃላይ ደግሞ 500 ጊባ አስተላልፈዋል ፡፡",
         "description": "Paragraph text in the 'Aggregated Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-para-3": {
-        "message": "Aggregated data is much less sensitive than activity data, but we still treat it as potentially sensitive and do not share it in this form.",
+        "message": "የተዋሃደ ውሂብ ከእንቅስቃሴው ውሂብ በጣም ያነሰ ስሜታዊ ነው ፣ ግን አሁንም እንደ ሚስጥራዊነት እናስተናግደዋለን በዚህ ቅፅ ላይ አናጋራም ፡፡",
         "description": "Paragraph text in the 'Aggregated Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-shareable-subhead": {
@@ -1576,19 +1600,19 @@
         "description": "Sub-heading for the definition of 'Shareable Aggregated Data' under the 'User Activity and VPN Data' section of the Privacy Policy page."
     },
     "privacy-information-collected-vpndata-shareable-para-1": {
-        "message": "When sharing aggregated data with third parties, we make sure that the data could not be combined with other sources to reveal user identities. For example, we do not share data for countries that only have a few Psiphon users in a day. We make sure that the data is anonymized.",
+        "message": "የተዋሃደ ውሂብን ከሶስተኛ ወገኖች ጋር ስናጋራ የተጠቃሚዎችን ማንነት ለማሳየት መረጃው ከሌሎች ምንጮች ጋር ሊጣመር እንደማይችል እናረጋግጣለን ፡፡ ለምሳሌ ፣ በቀን ውስጥ ጥቂት የፒፊሶን ተጠቃሚዎች ብቻ ላሏቸው አገራት ውሂብ አናጋራም። ውሂቡ ስም-አልባ መደረጉን እናረጋግጣለን።",
         "description": "Paragraph text in the 'Shareable Aggregated Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-shareable-para-2": {
-        "message": "We also never share domain-related information with third parties.",
+        "message": "እኛ እንዲሁ ከሶስተኛ ወገኖች ጋር ከጎራ ጋር የተዛመደ መረጃ በጭራሽ አናጋራም።",
         "description": "Paragraph text in the 'Shareable Aggregated Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-shareable-para-3": {
-        "message": "An example of shareable aggregated data might be: On a particular day, 500 people connected from New York City and transferred 800GB in total.",
+        "message": "የተጋራ ውህደት ምሳሌ ምሳሌ ምናልባት አንድ ቀን ከኒው ዮርክ ሲቲ የተገናኙ 500 ሰዎች በአጠቃላይ 800 ጊባ አስተላልፈዋል ፡፡",
         "description": "Paragraph text in the 'Shareable Aggregated Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-shareable-para-4": {
-        "message": "An example of data that is <em>not shareable</em>: On a particular day, 2 people connected from Los Angeles. Those people will be included in the stats for the entire US, but that is too few people to anonymously share city data for.",
+        "message": "<em>ሊጋራ የማይችል</em> የውሂብ ምሳሌ-በአንድ ቀን ፣ ከሎስ አንጀለስ የተገናኙ 2 ሰዎች። እነዚያ ሰዎች ለመላው አሜሪካ ስታቲስቲክስ ውስጥ ይካተታሉ ፣ ግን ያ ባልታወቁ ሰዎች የከተማ መረጃን ለማጋራት በጣም ጥቂት ናቸው ፡፡",
         "description": "Paragraph text in the 'Shareable Aggregated Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page. '<em>' is an HTML tag that adds emphasis (like italics), which can be used if it makes sense in your language."
     },
     "privacy-information-collected-vpndata-whatdoespsiphondowith-subhead-v2": {
@@ -1596,19 +1620,19 @@
         "description": "Sub-heading in the 'User Activity and VPN Data' section of the Privacy Policy page. The section describes what Psiphon does with the little bit of VPN data that it collects stats from."
     },
     "privacy-information-collected-vpndata-whatdoespsiphondowith-para-1-v2": {
-        "message": "Activity and aggregated statistical data are vital for us to make Psiphon work best. It allows us to do things like:",
+        "message": "Psiphon በተሻለ እንዲሠራ ለማድረግ እንቅስቃሴ እና አጠቃላይ የስታቲስቲክስ መረጃ ለእኛ በጣም አስፈላጊ ናቸው ፡፡ እንደዚህ ያሉ ነገሮችን ለማድረግ ያስችለናል",
         "description": "Paragraph text in the 'What does Psiphon do with User Activity and Aggregated Data?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whatdoespsiphondowith-para-2-item-1": {
-        "message": "Monitor the health and success of the Psiphon network: We need to know how many people are connecting, from where, how much data they're transferring, and if they're having any problems.",
+        "message": "የPsiphon አውታረ መረብን ጤና እና ስኬት ይቆጣጠሩ-ምን ያህል ሰዎች እንደሚገናኙ ፣ ከየት እንደ ሆኑ ፣ ምን ያህል ውሂብ እንደሚያስተላልፉ እና ምንም ዓይነት ችግር ከገጠማቸው መሆኑን ማወቅ አለብን ፡፡",
         "description": "Bullet list text under 'What does Psiphon do with User Activity and Aggregated Data?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whatdoespsiphondowith-para-2-item-2": {
-        "message": "Monitor threats to our users' devices: We watch for malware infections that attempt to contact command-and-control servers.",
+        "message": "በተጠቃሚዎቻችን መሣሪያዎች ላይ ስጋት ይቆጣጠር-የትእዛዝ እና ቁጥጥር አገልጋዮችን ለማነጋገር የሚሞክሩ ተንኮል-አዘል ዌር ኢንፌክሽኖችን እንጠብቃለን።",
         "description": "Bullet list text under 'What does Psiphon do with User Activity and Aggregated Data?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whatdoespsiphondowith-para-2-item-3": {
-        "message": "Ensure users stay connected while foiling censors: We try to detect that a user is behaving like a real person and then reveal new Psiphon servers to them. (This is our obfuscated server list technology.)",
+        "message": "የሸክላ ሳንቃዎች በሚሠሩበት ጊዜ ተጠቃሚዎች እንደተገናኙ መቆየታቸውን ያረጋግጡ-አንድ ተጠቃሚ ልክ እንደ እውነተኛ ሰው ባህሪ እያሳየ መሆኑን ለመለየት እንሞክራለን እና ከዚያ በኋላ አዲስ የፒፊሶን አገልጋዮችን ለእነሱ እንገልፃለን ፡፡ (ይህ የደመቀ የአገልጋይ ዝርዝር ቴክኖሎጂችን ነው።)",
         "description": "Bullet list text under 'What does Psiphon do with User Activity and Aggregated Data?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whydoespsiphonneed-para-1-item-1": {
@@ -1624,11 +1648,11 @@
         "description": "Bullet list text under 'What does Psiphon do with User Activity and Aggregated Data?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whopsiphonshareswith-subhead-v2": {
-        "message": "Who does Psiphon share Aggregated Data with?",
+        "message": "Psiphon የተሰበሰበውን ውሂብ ለማን ያጋራል?",
         "description": "Sub-heading in the 'User Activity and VPN Data' section of the Privacy Policy page. The section describes who Psiphon shares VPN data stats. The answer will be organizations and not specific people, in case that makes a difference in your language."
     },
     "privacy-information-collected-vpndata-whopsiphonshareswith-para-1-v2": {
-        "message": "Shareable aggregated data is shared with sponsors, organizations we collaborate with, and civil society researchers. The data can be used to show such things as:",
+        "message": "ሊጋራ የሚችል የተቀናጀ መረጃ ከስፖንሰር አድራጊዎች ፣ አብረን ካቀናበርናቸው ድርጅቶች እና ከሲቪል ማህበረሰብ ተመራማሪዎች ጋር ይጋራል ፡፡ ውሂቡ የሚከተሉትን የመሳሰሉ ነገሮችን ለማሳየት ሊያገለግል ይችላል-",
         "description": "Paragraph text in the 'Who does Psiphon share these statistics with?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whopsiphonshareswith-para-2-item-1": {
@@ -1640,19 +1664,19 @@
         "description": "Bullet list text under 'Who does Psiphon share Aggregated Data with?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whopsiphonshareswith-para-2-item-3": {
-        "message": "That the populace of a country is determined to access the open internet.",
+        "message": "የአንድ ሀገር ህዝብ ክፍት ኢንተርኔቱን ለመድረስ ቁርጥ ውሳኔ እንዳደረገ።",
         "description": "Bullet list text under 'Who does Psiphon share Aggregated Data with?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whopsiphonshareswith-para-3-v2": {
-        "message": "Again, only anonymized shareable aggregated data is ever shared with third parties.",
+        "message": "እንደገናም ፣ ከሶስተኛ ወገኖች ጋር መቼም ያልታወቁ የተጋራው አጠቃላይ ድምር ውሂብ ብቻ ሊጋራ ይችላል ፡፡",
         "description": "Paragraph text in the 'Who does Psiphon share these statistics with?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-psicash-para-1": {
-        "message": "The PsiCash system only collects information necessary for the functioning of the system, monitoring the health of the system, and ensuring the security of the system.",
+        "message": "የPsiCash ስርዓት ለስርዓቱ አሠራር አስፈላጊ የሆነውን መረጃ ይሰበስባል ፣ የስርዓቱን ጤና ይቆጣጠር እና የስርዓቱን ደህንነት ያረጋግጣል ፡፡",
         "description": "Paragraph text in the 'PsiCash' section of the Privacy page. 'PsiCash' must not be translated or transliterated."
     },
     "privacy-information-collected-psicash-para-2-list-start": {
-        "message": "The PsiCash server stores per-user information to allow for operation of the system, including:",
+        "message": "የPsiCash አገልጋይ የሚከተሉትን ጨምሮ የስርዓቱን ሥራ ለማስጀመር የሚያስችለውን መረጃ ያከማቻል-",
         "description": "Paragraph text in the 'PsiCash' section of the Privacy page. This is preamble to a detailed bullet list. 'PsiCash' must not be translated or transliterated."
     },
     "privacy-information-collected-psicash-para-2-item-1": {
@@ -1668,15 +1692,15 @@
         "description": "Bullet list item in the 'operation of the system' list. This item refers to the date and time that the user last earned or spent PsiCash."
     },
     "privacy-information-collected-psicash-para-2-item-4": {
-        "message": "PsiCash earning history, including what actions the rewards were granted for",
+        "message": "የPsiCash ገቢ ታሪክ /ለየትኛዎቹ ተግባራት ሽልማቶቹ እንደተሰጡ ጨምሮ/",
         "description": "Bullet list item in the 'operation of the system' list. This item refers to transaction history of the user earning PsiCash. 'PsiCash' must not be translated or transliterated."
     },
     "privacy-information-collected-psicash-para-2-item-5": {
-        "message": "PsiCash spending history, including what purchases were made",
+        "message": "የPsiCash ወጪ ታሪክ /የተፈጸሙትን ግዢዎችን ጨምሮ/",
         "description": "Bullet list item in the 'operation of the system' list. This item refers to transaction history of the user spending PsiCash, such as by buying Speed Boost. 'PsiCash' must not be translated or transliterated."
     },
     "privacy-information-collected-psicash-para-3-list-start": {
-        "message": "In the user's web browser, some data is stored to allow for earning rewards and making purchases. This data includes:",
+        "message": "በተጠቃሚው ድር አሳሽ ውስጥ ሽልማቶችን ለማግኘት እና ግsesዎችን ለማከናወን አንዳንድ ውሂብ ይቀመጣል። ይህ ውሂብ የሚከተሉትን ያጠቃልላል፦",
         "description": "Paragraph text in the 'PsiCash' section of the Privacy page. This is preamble to a detailed bullet list. 'PsiCash' must not be translated or transliterated."
     },
     "privacy-information-collected-psicash-para-3-item-1": {

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "يرجى من عملاء سايفون Psiphon استخدام عناصر المصدر المفتوح التالية.",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "ويندوز :",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "أندرويد:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "تنزيل ",
@@ -1251,6 +1239,22 @@
         "message": "متى نعمل ذلك؟",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "تحديث",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "أي بيانات مستخدم سيتم جمعها؟",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "سياسة الخصوصية",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/az/messages.json
+++ b/_locales/az/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon proqramı aşağıdakı açıq mənbə komponenetlərini istifadə edir:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "yüklə",
@@ -1251,6 +1239,22 @@
         "message": "Bunu nə vaxt edirik",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Yenilə",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Hansı istifadəçi məlumatları toplanır",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Təhlükəsizlik Siyasəti",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/be/messages.json
+++ b/_locales/be/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Кліенты Psiphon выкарыстоўваюць наступныя элементы адкрытых зыходных кодаў:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "загрузіць",
@@ -1251,6 +1239,22 @@
         "message": "Калі мы гэта робім",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Абнавіць",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Якія даныя пра карыстальніка будуць збірацца",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Палітыка канфідэнцыяльнасці",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "সাইফন ক্লায়েন্ট নিম্নলিখিত মুক্ত বা খোলা উৎস উপাদানগুলি ব্যবহার করে:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "উইন্ডোজ:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "অ্যান্ড্রয়েড",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "ডাউনলোড",
@@ -1251,6 +1239,22 @@
         "message": "আমরা যখন এটা করছি",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "হালনাগাদ",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "কি ব্যবহারকারী ডেটা সংগ্রহ করা হবে",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "গোপনীয়তা নীতি",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/bo/messages.json
+++ b/_locales/bo/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "སཡི་ཕོན་མཉེན་ཆས་ཀྱིས་་གཤམ་དུ་ཡོད་པའི་ཕྱི་གསལ་ནང་གསལ་གྱི་ཨང་རྟགས་ཁག་ལ་བེད་སྤྱོད་བྱེད་ཀྱི་ཡོད།:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "ཝིན་ཌོ།",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "ཨེན་ཀྲཌོ",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "ཕབ་ལེན།",
@@ -1251,6 +1239,22 @@
         "message": "ང་ཚོས་ག་དུས་བྱེད་ཀྱི་ཡོད་དམ།",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "གསར་སྒྱུར།",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "སྤྱོད་མཁན་གྱི་གྲངས་ཐོ་གང་དང་གང་བསྡུ་གི་ཡོད།",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "གསང་དོན་སྲིད་བྱུས།",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon-Clients verwenden die folgenden quelloffenen Komponenten:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "herunterladen",
@@ -1251,6 +1239,22 @@
         "message": "Wann wir es machen",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Aktualisieren",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Welche Benutzerdaten werden gesammelt",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Datenschutzerklärung",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon clients use the following open source components:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows: ",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android: ",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "λήψη",
@@ -1251,6 +1239,22 @@
         "message": "Πότε το κάνουμε",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Update",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Ποιά δεδομένα χρήστη συλλέγονται",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Πολιτική Απορρήτου",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,11 +1,7 @@
 {
-  "psiphon": {
-    "message": "Psiphon",
-    "description": "The name of the product. Probably not translated or transliterated for most languages"
-  },
   "site-title": {
     "message": "Psiphon: free your net",
-    "description": "the title for the site"
+    "description": "The title for the site. 'Psiphon' must not be translated or transliterated."
   },
   "index-meta-title": {
     "message": "Uncensored Internet access for Windows and Mobile",
@@ -13,15 +9,11 @@
   },
   "index-description": {
     "message": "Psiphon is circumvention software for Windows and Mobile platforms that provides uncensored access to Internet content",
-    "description": "Page description for the index page"
+    "description": "Page description for the index page. 'Psiphon' must not be translated or transliterated."
   },
   "index-hero-subtext": {
     "message": "beyond borders",
     "description": "Slogan text that appears below the hero image on the main page. Should be in all lower-case, as it will be shown with 'small caps' -- but if that doesn't make sense in your language, feel free to use mixed case."
-  },
-  "index-hero-alt": {
-    "message": "Psiphon",
-    "description": "Alt text for hero image that appears on main page and says 'Psiphon' in a stylized font"
   },
   "nav-language-title" : {
     "message": "Choose your language"
@@ -43,7 +35,7 @@
   },
   "faq-description": {
     "message": "Answers to frequently asked questions about Psiphon",
-    "description": "description for the FAQ page"
+    "description": "Description for the FAQ page. 'Psiphon' must not be translated or transliterated."
   },
   "resources-nav-title": {
     "message": "Resources",
@@ -51,11 +43,11 @@
   },
   "user-guide-title": {
     "message": "How to Use Psiphon",
-    "description": "page title for the user guide page"
+    "description": "Page title for the user guide page. 'Psiphon' must not be translated or transliterated."
   },
   "user-guide-meta-title": {
     "message": "How to use Psiphon on Mobile and Windows",
-    "description": "meta title for the user guide page"
+    "description": "Meta title for the user guide page. 'Psiphon' must not be translated or transliterated."
   },
   "user-guide-nav-title": {
     "message": "User Guide",
@@ -63,11 +55,11 @@
   },
   "user-guide-description": {
     "message": "Psiphon user guide showing how to use Psiphon on Mobile and Windows platforms",
-    "description": "description for the user guide page"
+    "description": "Description for the user guide page. 'Psiphon' must not be translated or transliterated."
   },
   "download-title": {
     "message": "Download Psiphon",
-    "description": "page title for the download page"
+    "description": "Page title for the download page. 'Psiphon' must not be translated or transliterated."
   },
   "download-meta-title": {
     "message": "Download Android app and Windows client",
@@ -79,11 +71,11 @@
   },
   "download-description": {
     "message": "Direct, free Psiphon download for Windows and Android",
-    "description": "title for the download page"
+    "description": "Title for the download page. 'Psiphon' must not be translated or transliterated."
   },
   "faq-section-verify-psiphon-authentic": {
     "message": "Verify Your Psiphon Download is Authentic",
-    "description": "Section heading for FAQ entries that help users to make sure the Psiphon client they downloaded is authentic and legitimate."
+    "description": "Section heading for FAQ entries that help users to make sure the Psiphon client they downloaded is authentic and legitimate. 'Psiphon' must not be translated or transliterated."
   },
   "faq-section-privacy-security": {
     "message": "Privacy and Security",
@@ -91,11 +83,11 @@
   },
   "faq-section-installing-running-updating": {
     "message": "Installing, Running, and Updating Psiphon",
-    "description": "Section heading for FAQ entries that pertain to running and installing/updating/upgrading the Psiphon client software."
+    "description": "Section heading for FAQ entries that pertain to running and installing/updating/upgrading the Psiphon client software. 'Psiphon' must not be translated or transliterated."
   },
   "faq-section-how-psiphon-works": {
     "message": "How Psiphon Works",
-    "description": "Section heading for FAQ entries that pertain to explaining how Psiphon works -- that is, how it helps users to circumvent/bypass censorship."
+    "description": "Section heading for FAQ entries that pertain to explaining how Psiphon works -- that is, how it helps users to circumvent/bypass censorship. 'Psiphon' must not be translated or transliterated."
   },
   "faq-section-troubleshooting": {
     "message": "Troubleshooting",
@@ -119,13 +111,15 @@
   },
   "faq-authentic-windows-image-alt": {
     "message": "The flow of dialog boxes required to find the certificate thumbprint for Psiphon for Windows",
-    "description": "alt text for an image"
+    "description": "Alt text for an image. 'Psiphon' must not be translated or transliterated."
   },
   "faq-authentic-windows-question": {
-    "message": "Is my Psiphon for Windows authentic?"
+    "message": "Is my Psiphon for Windows authentic?",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-authentic-windows-answer-para-1": {
-    "message": "Psiphon for Windows is never distributed as an installable package. Each Psiphon for Windows client is a single executable file (\".exe\") that is digitally signed by Psiphon Inc. Windows automatically checks this signature when you run the client. You can also manually inspect the signature before running the client by invoking the Properties dialog for the file and inspecting the Digital Signatures tab. The SHA1 thumbprint for the Psiphon Inc. certificate public key is displayed in the Certificate dialog Details tab."
+    "message": "Psiphon for Windows is never distributed as an installable package. Each Psiphon for Windows client is a single executable file (\".exe\") that is digitally signed by Psiphon Inc. Windows automatically checks this signature when you run the client. You can also manually inspect the signature before running the client by invoking the Properties dialog for the file and inspecting the Digital Signatures tab. The SHA1 thumbprint for the Psiphon Inc. certificate public key is displayed in the Certificate dialog Details tab.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-authentic-windows-answer-para-2020": {
     "message": "For the certificate valid for the period 2017-07-05 to 2020-10-03 the SHA1 thumbprint is:",
@@ -144,26 +138,30 @@
     "description": "The Psiphon for Windows client can be authenticated by checking the certificate used to sign it has the correct thumbprint. The certificate is valid for a certain date range, and the thumbprint is shown below this sentence. 'SHA1' is the name of a hash algorithm, used to calculate the thumbprint (and is probably not translated)."
   },
   "faq-authentic-windows-answer-para-4": {
-    "message": "Psiphon for Windows auto-updates itself, and this process automatically verifies that each update is authentic."
+    "message": "Psiphon for Windows auto-updates itself, and this process automatically verifies that each update is authentic.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-authentic-android-question": {
-    "message": "Is my Psiphon for Android authentic?"
+    "message": "Is my Psiphon for Android authentic?",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-authentic-android-answer-alert": {
     "message": "<b>ALERT:</b> A recently <a href=\"http://www.zdnet.com/google-releases-fix-to-oems-for-blue-security-android-security-hole-7000017782/\">reported</a> vulnerability may cause Android app signature checking to falsely report malicious APKs as valid. We recommend that users turn on the Google Verify Apps feature as documented <a href=\"https://support.google.com/accounts/answer/2812853?hl=en\">here</a>."
   },
   "faq-authentic-android-answer-para-1": {
-    "message": "Each Psiphon for Android client is shipped as an Android APK file (\".apk\") that is digitally signed by Psiphon Inc. The Psiphon Inc. certificate public key is as follows:"
+    "message": "Each Psiphon for Android client is shipped as an Android APK file (\".apk\") that is digitally signed by Psiphon Inc. The Psiphon Inc. certificate public key is as follows:",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-authentic-android-answer-para-2": {
     "message": "An APK may be validated by (1) extracting the certificate from the archive and checking that its fingerprints matches the value above and (2) verifying that the APK is signed with the certificate. For example, using Unix and Java command-line tools:"
   },
   "faq-authentic-android-answer-para-3": {
-    "message": "Psiphon for Android auto-updates itself, and this process automatically verifies that each update is authentic."
+    "message": "Psiphon for Android auto-updates itself, and this process automatically verifies that each update is authentic.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-unsupported-platforms-question": {
     "message": "Is Psiphon available for macOS, Linux, Windows Phone, etc.?",
-    "description": "FAQ question."
+    "description": "FAQ question. 'Psiphon' must not be translated or transliterated."
   },
   "faq-unsupported-platforms-answer-para-1": {
     "message": "The platforms we support are those available on the <a href=\"download.html\">Download page</a>. We are constantly working to expand our platform support, so hopefully we'll support your desired OS in the near future!",
@@ -179,7 +177,7 @@
   },
   "faq-android-enable-sideloading-answer-para-1": {
     "message": "In order to install a direct download of Psiphon for Android, you must enable sideloading on your device. To do so, go into your Android settings, then into the “Security” section, then enable “Unknown sources”.",
-    "description": "Part of the answer to the FAQ question 'How do I enable Android “Sideloading”?'"
+    "description": "Part of the answer to the FAQ question 'How do I enable Android “Sideloading”?' 'Psiphon' must not be translated or transliterated."
   },
   "faq-android-enable-sideloading-image-alt": {
     "message": "Screenshot of the Android security setting that allows installation of non-Play Store apps",
@@ -187,55 +185,58 @@
   },
   "faq-windows-xp-eol-question": {
     "message": "Does Psiphon for Windows work on Windows XP or Vista?",
-    "description": "FAQ question."
+    "description": "FAQ question. 'Psiphon' must not be translated or transliterated."
   },
   "faq-windows-xp-eol-answer-para-1": {
     "message": "As of December 2019, Psiphon does not support Windows XP or Vista. A legacy build <a href=\"https://psiphon.s3.amazonaws.com/legacy/psiphon3-legacy.exe\">is available for download</a> that will work on those platforms for the foreseeable future, but users are strongly encouraged to upgrade to a recent version of Windows.",
-    "description": "FAQ answer to the question 'Does Psiphon for Windows work on Windows XP or Vista?'"
+    "description": "FAQ answer to the question 'Does Psiphon for Windows work on Windows XP or Vista?' 'Psiphon' must not be translated or transliterated."
   },
   "faq-information-collected-answer-redirect": {
     "message": "Please see our <a href=\"privacy.html\">Privacy Policy</a> to learn about what information we collect.",
     "description": "This is the FAQ answer to the question 'What info does Psiphon collect?' The user needs to go to a separate page to see the full answer."
   },
   "faq-ip-change-question": {
-    "message": "Why does my Psiphon IP address frequently change?"
+    "message": "Why does my Psiphon IP address frequently change?",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-ip-change-answer-para-1": {
-    "message": "Your Psiphon client will automatically discover new Psiphon servers. When the last server used is currently unavailable, another one can be used instead."
+    "message": "Your Psiphon client will automatically discover new Psiphon servers. When the last server used is currently unavailable, another one can be used instead.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-connection-failed-question": {
     "message": "Why do I see the message \"connection failed\" repeating over and over?"
   },
   "faq-connection-failed-answer-para-1": {
-    "message": "If you see repeated \"connection failed\" messages, it means that there are no available servers that your client knows about. Try to download a new Psiphon client."
+    "message": "If you see repeated \"connection failed\" messages, it means that there are no available servers that your client knows about. Try to download a new Psiphon client.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-reset-system-proxy-question": {
     "message": "After using Psiphon for Windows my computer can no longer connect to the Internet.",
-    "description": "FAQ question."
+    "description": "FAQ question. 'Psiphon' must not be translated or transliterated."
   },
   "faq-reset-system-proxy-answer-para-1": {
     "message": "When Psiphon for Windows connects it modifies your computer's proxy settings, and when it disconnects it restores them to their original state. If Psiphon for Windows does not exit properly, it may not properly restore the original proxy settings, and this will result in you being unable to connect to the Internet.",
-    "description": "FAQ answer to the question 'After using Psiphon for Windows my computer can no longer connect to the Internet.'"
+    "description": "FAQ answer to the question 'After using Psiphon for Windows my computer can no longer connect to the Internet.' 'Psiphon' must not be translated or transliterated."
   },
   "faq-reset-system-proxy-answer-para-2": {
     "message": "The easiest way to fix this for most people is to connect with Psiphon again, and then cleanly disconnect.",
-    "description": "FAQ answer to the question 'After using Psiphon for Windows my computer can no longer connect to the Internet.'"
+    "description": "FAQ answer to the question 'After using Psiphon for Windows my computer can no longer connect to the Internet.' 'Psiphon' must not be translated or transliterated."
   },
   "faq-reset-system-proxy-answer-para-3": {
     "message": "To manually fix your proxy settings, open Internet Explorer, then go to the Tools menu (or gear icon), Internet Options → Connections tab → LAN Settings button. Then remove the checkmark beside “Use a proxy server for your LAN”.",
-    "description": "FAQ answer to the question 'After using Psiphon for Windows my computer can no longer connect to the Internet.'"
+    "description": "FAQ answer to the question 'After using Psiphon for Windows my computer can no longer connect to the Internet.' 'Psiphon' must not be translated or transliterated."
   },
   "faq-android-upgrade-bug-question": {
     "message": "After upgrading the Psiphon for Android app, it won't connect.",
-    "description": "FAQ question."
+    "description": "FAQ question. 'Psiphon' must not be translated or transliterated."
   },
   "faq-android-upgrade-bug-answer-para-1": {
     "message": "If Psiphon is connected while an upgrade is installed, it may not be able to connect afterwards and will show the error “start_tunnel_failed application is not prepared or revoked”. This is due to an <a href=\"https://code.google.com/p/android/issues/detail?id=80074\" target=\"_blank\">Android OS bug</a>. This condition can be fixed by rebooting your device.",
-    "description": "FAQ answer to the question 'After upgrading the Psiphon for Android app, it won't connect.'"
+    "description": "FAQ answer to the question 'After upgrading the Psiphon for Android app, it won't connect.' 'Psiphon' must not be translated or transliterated."
   },
   "faq-periodic-disconnect-question": {
     "message": "Why does my Psiphon connection sometimes disconnect?",
-    "description": "FAQ question."
+    "description": "FAQ question. 'Psiphon' must not be translated or transliterated."
   },
   "faq-periodic-disconnect-answer-para-1": {
     "message": "This is most commonly caused by an unreliable or inconsistent Internet connection to your device or computer. On a phone, this can mean losing reception. On a computer, this can mean inconsistent Wi-Fi or an unreliable Internet Service Provider.",
@@ -243,11 +244,11 @@
   },
   "faq-ie6-docbody-question": {
     "message": "Psiphon for Windows gives the error “doc.body is null or not an object” and does not work.",
-    "description": "FAQ question."
+    "description": "FAQ question. 'Psiphon' must not be translated or transliterated."
   },
   "faq-ie6-docbody-answer-para-1": {
     "message": "This error will occur on Windows XP if Internet Explorer 6 is installed. Psiphon for Windows requires Internet Explorer 7 or higher to be installed. The best way to install higher versions of Internet Explorer is via <a href=\"http://windows.microsoft.com/en-us/windows/windows-update\" target=\"_blank\">Windows Update</a>.",
-    "description": "FAQ answer to the question 'Psiphon for Windows gives the error “doc.body is null or not an object” and does not work.'"
+    "description": "FAQ answer to the question 'Psiphon for Windows gives the error “doc.body is null or not an object” and does not work.' 'Psiphon' must not be translated or transliterated."
   },
   "faq-ie6-docbody-answer-para-2": {
     "message": "If you can't use Windows Update and want to install Internet Explorer 7 or Internet Explorer 8 directly, you can get them via these links:",
@@ -262,86 +263,95 @@
     "description": "FAQ answer to the question 'Psiphon for Windows gives the error “doc.body is null or not an object” and does not work.' This text is used as a link to a download."
   },
   "faq-check-version-question": {
-    "message": "How do I check my current version of Psiphon?"
+    "message": "How do I check my current version of Psiphon?",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-check-version-answer-para-1": {
-    "message": "When Psiphon starts, it displays the Client Version on the first line of log output."
+    "message": "When Psiphon starts, it displays the Client Version on the first line of log output.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-get-updated-version-question": {
     "message": "How do I get an updated version of Psiphon?",
-    "description": "FAQ question"
+    "description": "FAQ question. 'Psiphon' must not be translated or transliterated."
   },
   "faq-get-updated-version-answer-para-1": {
     "message": "<strong>Android:</strong> If you have installed Psiphon for Android through the Google Play Store, it will be automatically updated by the Play Store when an update is available. If you have sideloaded Psiphon for Android, the Psiphon client will download updates as they are available, and a notification will appear asking you to install the update.",
-    "description": "FAQ answer to the question 'How do I get an updated version of Psiphon?' for Android users."
+    "description": "FAQ answer to the question 'How do I get an updated version of Psiphon?' for Android users. 'Psiphon' must not be translated or transliterated."
   },
   "faq-get-updated-version-answer-para-2": {
     "message": "<strong>Windows:</strong> The Psiphon for Windows client will download and install updates as they are available.",
-    "description": "FAQ answer to the question 'How do I get an updated version of Psiphon?' for Windows users."
+    "description": "FAQ answer to the question 'How do I get an updated version of Psiphon?' for Windows users. 'Psiphon' must not be translated or transliterated."
   },
   "faq-get-updated-version-answer-para-3": {
     "message": "<strong>Manually updating:</strong> If the Psiphon self-updating mechanism isn't working (for example, if it's been blocked), you can find information about getting a fresh copy of Psiphon from the <a href=\"download.html\">Download page</a>.",
-    "description": "FAQ answer to the question 'How do I get an updated version of Psiphon?' if the user believes that the automatic updating feature isn't working (or is blocked)."
+    "description": "FAQ answer to the question 'How do I get an updated version of Psiphon?' if the user believes that the automatic updating feature isn't working (or is blocked). 'Psiphon' must not be translated or transliterated."
   },
   "faq-orig-file-purpose-question": {
-    "message": "What is the file “psiphon3.exe.orig”?"
+    "message": "What is the file “psiphon3.exe.orig”?",
+    "description": "Do no translate or transliterate the filename."
   },
   "faq-orig-file-purpose-answer-para-1": {
-    "message": "The automatic update process in Psiphon for Windows renames its old version to “psiphon3.exe.orig”. Old files with the “.orig” suffix can safely be deleted."
+    "message": "The automatic update process in Psiphon for Windows renames its old version to “psiphon3.exe.orig”. Old files with the “.orig” suffix can safely be deleted.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-uninstall-windows-question": {
     "message": "How do I uninstall Psiphon for Windows?",
-    "description": "FAQ question"
+    "description": "FAQ question. 'Psiphon' must not be translated or transliterated."
   },
   "faq-uninstall-windows-answer-para-1": {
     "message": "Psiphon for Windows does not get installed, and won't appear in Windows’ “Add or Remove Programs” list. The executable file can be run from your “Downloads” directory, or it can be copied to a different directory and run from there. If you want to remove the program, you can simply delete the executable file.",
-    "description": "FAQ answer to the question 'How do I uninstall Psiphon for Windows?'"
+    "description": "FAQ answer to the question 'How do I uninstall Psiphon for Windows?' 'Psiphon' must not be translated or transliterated."
   },
   "faq-clear-windows-data-question": {
     "message": "How do I clear Psiphon for Windows' local data?",
-    "description": "FAQ question"
+    "description": "FAQ question. 'Psiphon' must not be translated or transliterated."
   },
   "faq-clear-windows-data-answer-para-1": {
     "message": "Psiphon for Windows stores some data locally under the user's profile. It is located at a path like <code>C:\\Users\\YourName\\AppData\\Roaming\\Psiphon3</code>; or, more generally, <code>%APPDATA%\\Psiphon3</code>. You can delete the local data by going to that path in Windows Explorer and deleting it, or entering this command at a command prompt: <code>rmdir /s \"%APPDATA%\\Psiphon3\"</code>.",
-    "description": "FAQ answer to the question 'How do I clear Psiphon for Windows' local data?'"
+    "description": "FAQ answer to the question 'How do I clear Psiphon for Windows' local data?' 'Psiphon' must not be translated or transliterated."
   },
   "faq-proxy-all-question": {
-    "message": "Does Psiphon for Windows proxy all of my Internet traffic?"
+    "message": "Does Psiphon for Windows proxy all of my Internet traffic?",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-proxy-all-answer-para-1": {
-    "message": "Only in VPN mode. After a successful connection is established in VPN mode, your entire computer’s traffic will pass through the Psiphon network. When VPN mode is not enabled only applications that use the local HTTP and SOCKS proxies will be proxied."
+    "message": "Only in VPN mode. After a successful connection is established in VPN mode, your entire computer’s traffic will pass through the Psiphon network. When VPN mode is not enabled only applications that use the local HTTP and SOCKS proxies will be proxied.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-proxy-all-ios-browser-question": {
-    "message": "Does Psiphon Browser for iOS proxy all of my device's Internet traffic?"
+    "message": "Does Psiphon Browser for iOS proxy all of my device's Internet traffic?",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-proxy-all-ios-browser-answer-para-1": {
-    "message": "Psiphon Browser for iOS is a browser-only application and so will only tunnel data that is loaded in the app itself, and will not tunnel your other apps (like your Facebook or Twitter apps) through the Psiphon network. So, for example, if you wanted to use the Psiphon network to access your Facebook account, you would use Psiphon Browser to go the Facebook website. If you were to open your Facebook app, it would use your direct internet connection, and would not be tunneled through the Psiphon network."
+    "message": "Psiphon Browser for iOS is a browser-only application and so will only tunnel data that is loaded in the app itself, and will not tunnel your other apps (like your Facebook or Twitter apps) through the Psiphon network. So, for example, if you wanted to use the Psiphon network to access your Facebook account, you would use Psiphon Browser to go the Facebook website. If you were to open your Facebook app, it would use your direct internet connection, and would not be tunneled through the Psiphon network.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-browser-compatibility-question": {
-    "message": "Is Psiphon for Windows compatible with Internet Explorer, Firefox, and Chrome web browsers?"
+    "message": "Is Psiphon for Windows compatible with Internet Explorer, Firefox, and Chrome web browsers?",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-browser-compatibility-answer-para-1": {
     "message": "Yes. Check your browser settings and make sure that it is configured to use the system proxy settings."
   },
   "faq-port-restrictions-question": {
     "message": "Are there any port restrictions when using Psiphon?",
-    "description": "FAQ question. Note that 'port' is referring to network ports."
+    "description": "FAQ question. Note that 'port' is referring to network ports. 'Psiphon' must not be translated or transliterated."
   },
   "faq-port-restrictions-answer-para-1": {
     "message": "Outbound connections via the Psiphon network can only be made to a restricted set of server ports including: <code>53, 80, 443, 465, 587, 993, 995, 8000, 8001, 8080</code>. See <a href=\"https://groups.google.com/group/psiphon3/browse_thread/thread/8a7f3c42c5dd89e1\">this discussion</a> for more information. Mail clients cannot establish outbound connections on port 25. See <a href=\"https://groups.google.com/group/psiphon3/browse_thread/thread/2ef3a0af447ccd64\">this discussion</a> for more information.",
-    "description": "FAQ answer to the question 'Are there any port restrictions when using Psiphon?'"
+    "description": "FAQ answer to the question 'Are there any port restrictions when using Psiphon?' 'Psiphon' must not be translated or transliterated."
   },
   "faq-mail-apps-ports-question": {
     "message": "Why can't I use my favorite app while Psiphon is running? Why can't I send email using my mail client?",
-    "description": "FAQ question."
+    "description": "FAQ question. 'Psiphon' must not be translated or transliterated."
   },
   "faq-mail-apps-ports-answer-para-1": {
     "message": "This is probably due to Psiphon's <a href=\"#port-restrictions\">port restrictions</a>.",
-    "description": "FAQ answer to the question 'Why can't I use my favorite app while Psiphon is running? Why can't I send email using my mail client?'"
+    "description": "FAQ answer to the question 'Why can't I use my favorite app while Psiphon is running? Why can't I send email using my mail client?' 'Psiphon' must not be translated or transliterated."
   },
   "faq-mobile-hotspot-question": {
     "message": "Why do Android mobile hotspot and USB tethering not work through Psiphon?",
-    "description": "FAQ question."
+    "description": "FAQ question. 'Psiphon' must not be translated or transliterated."
   },
   "faq-mobile-hotspot-answer-para-1": {
     "message": "This is due to a limitation in Android's hotspot and tethering implementation. You might find that either the tethered device cannot connect to the internet or the traffic will not go through the VPN.",
@@ -349,19 +359,19 @@
   },
   "faq-av-firewall-question": {
     "message": "Why does my antivirus (AV) or firewall identify Psiphon as a threat?",
-    "description": "FAQ question."
+    "description": "FAQ question. 'Psiphon' must not be translated or transliterated."
   },
   "faq-av-firewall-answer-para-1": {
     "message": "The first thing to check is that you have an authentic copy of Psiphon. Please <a href=\"#verify-psiphon-authentic\">follow these instructions</a> to verify that your copy of Psiphon is authentic. If it is not authentic, please <a href=\"mailto:info@psiphon.ca\">send us an email</a> with information about how you obtained the copy and, if possible, with the Psiphon executable attached.",
-    "description": "FAQ answer to the question 'Why does my antivirus or firewall identify Psiphon as a threat?'"
+    "description": "FAQ answer to the question 'Why does my antivirus or firewall identify Psiphon as a threat?' 'Psiphon' must not be translated or transliterated."
   },
   "faq-av-firewall-answer-para-2": {
     "message": "If your copy of Psiphon is authentic, then this is an instance of a false positive report. Although most antivirus/firewall programs have added Psiphon’s digital signature to their whitelist rules, some may still erroneously identify Psiphon’s executable file as a virus or threat. In this case, please <a href=\"mailto:info@psiphon.ca\">send us an email</a>, specifying the AV/firewall program you use, and we will contact the AV/firewall vendor to solve the problem.",
-    "description": "FAQ answer to the question 'Why does my antivirus or firewall identify Psiphon as a threat?'"
+    "description": "FAQ answer to the question 'Why does my antivirus or firewall identify Psiphon as a threat?' 'Psiphon' must not be translated or transliterated."
   },
   "faq-windows-metro-question": {
     "message": "Why can't I tunnel my Windows Metro (aka Modern UI) apps through Psiphon?",
-    "description": "FAQ question. 'Metro' or 'Modern' is the fancy user interface that Microsoft introduced with Windows 8."
+    "description": "FAQ question. 'Metro' or 'Modern' is the fancy user interface that Microsoft introduced with Windows 8. 'Psiphon' must not be translated or transliterated."
   },
   "faq-windows-metro-answer-para-1": {
     "message": "Windows 8 introduced an alternative to the desktop app interface called “Metro”, which was later renamed to “Modern UI”. Some, but very few, applications can only run in “Metro mode” and some (like Internet Explorer) can run in either “Metro mode” or “Desktop mode”. This new user interface mode continues to exist in Windows 8.1 and, to a lesser degree, in Windows 10.",
@@ -369,32 +379,38 @@
   },
   "faq-windows-metro-answer-para-2": {
     "message": "Applications in Metro mode cannot use a local proxy without the user modifying system security settings. This means that Metro mode apps cannot use Psiphon, and will not be able to reach the internet when Psiphon is connected. You can use the <a href=\"https://blogs.msdn.microsoft.com/fiddler/2011/12/10/revisiting-fiddler-and-win8-immersive-applications/\" target=\"_blank\">EnableLoopback Utility</a> to allow Metro mode apps to work with Psiphon.",
-    "description": "FAQ answer to the question 'Why can't I tunnel my Windows Metro (aka Modern UI) apps through Psiphon?' 'EnableLoopback' should not be translated."
+    "description": "FAQ answer to the question 'Why can't I tunnel my Windows Metro (aka Modern UI) apps through Psiphon?' 'EnableLoopback' should not be translated. 'Psiphon' must not be translated or transliterated."
   },
   "faq-windows-metro-answer-para-3": {
     "message": "The following are examples of the error message you might see when Metro mode apps are trying and failing to work through Psiphon.",
-    "description": "FAQ answer to the question 'Why can't I tunnel my Windows Metro (aka Modern UI) apps through Psiphon?' This sentence is followed by two screenshots of error messages."
+    "description": "FAQ answer to the question 'Why can't I tunnel my Windows Metro (aka Modern UI) apps through Psiphon?' This sentence is followed by two screenshots of error messages. 'Psiphon' must not be translated or transliterated."
   },
   "faq-vpn-protocol-question": {
-    "message": "What VPN protocol is used by Psiphon for Windows? Why can't I connect?"
+    "message": "What VPN protocol is used by Psiphon for Windows? Why can't I connect?",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-vpn-protocol-answer-para-1": {
-    "message": "Psiphon uses the L2TP/IPsec VPN protocol."
+    "message": "Psiphon uses the L2TP/IPsec VPN protocol.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-windows-vpn-connect-question": {
-    "message": "Why can't I connect with Psiphon for Windows in L2TP/IPsec mode?"
+    "message": "Why can't I connect with Psiphon for Windows in L2TP/IPsec mode?",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-windows-vpn-connect-answer-para-1": {
     "message": "Your network's firewall may not allow the use of VPNs. Your home router may not be configured to pass through this VPN protocol; check your firewall settings to see that IPsec or L2TP pass-through is enabled. Your system’s IPsec Services may be disabled; check your service settings and enable these services to start automatically."
   },
   "faq-vpn-slow-question": {
-    "message": "I can connect to Psiphon for Windows in VPN mode, but why is it so slow?  Sometimes web pages don't load at all."
+    "message": "I can connect to Psiphon for Windows in VPN mode, but why is it so slow?  Sometimes web pages don't load at all.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-vpn-slow-answer-para-1": {
-    "message": "Certain networking hardware or Internet connections may cause performance problems for L2TP/IPsec which is the protocol used by Psiphon in VPN mode. Try disabling VPN mode."
+    "message": "Certain networking hardware or Internet connections may cause performance problems for L2TP/IPsec which is the protocol used by Psiphon in VPN mode. Try disabling VPN mode.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-vpn-dns-question": {
-    "message": "When I connect to Psiphon for Windows in VPN mode, none of my web pages load. I get error messages indicating that a domain lookup failed."
+    "message": "When I connect to Psiphon for Windows in VPN mode, none of my web pages load. I get error messages indicating that a domain lookup failed.",
+    "description": "'Psiphon' must not be translated or transliterated."
   },
   "faq-vpn-dns-answer-para-1": {
     "message": "Psiphon restricts DNS traffic to white-listed, vetted DNS servers. The Psiphon client automatically configures your VPN DNS server settings. If you're getting errors related to DNS, check that you're not infected by the \"DNS Changer\" malware, which tries to change your DNS server settings. More info can be found <a href=\"https://en.wikipedia.org/wiki/DNSChanger\">here</a>."

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Los clientes Psiphon usan los siguientes componentes de código abierto:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows: ",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "descarga",
@@ -1251,6 +1239,22 @@
         "message": "Cuándo lo estamos haciendo",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Actualizar",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Qué datos de usuario estamos recogiendo",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Política de privacidad",
@@ -1551,8 +1575,8 @@
         "message": "Un ejemplo de actividad de datos de usuario puede ser: en un momento determinado un usuario conectado desde la ciudad de New York, usando Comcast, transfirió 100MB desde <code>youtube.com</code> y 300MB en total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon متن باز است.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "کارخواه Psiphon از این قطعات متن باز استفاده میکند: ",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "ویندوز:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "اندورید:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "دانلود",
@@ -1251,6 +1239,22 @@
         "message": "چه زمانی این کار را انجام می دهیم",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "به روز رسانی",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "چه داده هایی از کاربر جمع آوری خواهد شد",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "با شروع ‎2019-12-12T00: 00Z اعمال خواهد شد. برای مدت یک ماه قابل اجرا خواهد بود. در صورت نیاز به فراتر از آن، این خبرنامه را به‌روز خواهیم کرد.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "حریم خصوصی",
@@ -1551,8 +1575,8 @@
         "message": "یک مثال از داده های فعالیت کاربر می‌تواند اینگونه باشد: در یک زمان خاص، کاربر متصل از شهر نیویورک، با استفاده از Comcast، و 100 مگابایت را از <code>youtube.com</code>و 300 مگابایت را در کل منتقل کرد.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "ما داده‌های فعالیت کاربر را  جزء حساس‌ترین طبقه داده‌ها، تلقی می‌کنیم. ما هرگز، به هیچ وجه این داده‌ها را با اشخاص ثالث به اشتراک نمی‌گذاریم. ما اطلاعات فعالیت کاربر را حداکثر 60 روز نگه داشته، و سپس آن را تجمیع کرده و حذف می‌کنیم. نسخه‌های پشتیبان تهیه‌شده از آن داده‌ها برای مدت زمان معقولی نگهداری می‌شوند.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/fa_AF/messages.json
+++ b/_locales/fa_AF/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "سرویس‌گیرنده گان سایفون از اجزای منبع باز ذیل استفاده میکنند:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "ویندوز:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "اندرواید:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "دانلود",
@@ -1251,6 +1239,22 @@
         "message": "چی وقت این کار را انجام میدهیم",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "به‌روزسازی",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "کدام داده‌های کاربر جمع‌آوری خواهد شد",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "پالیسی حفظ حریم خصوصی",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon clients use the following open source components:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "lataa",
@@ -1251,6 +1239,22 @@
         "message": "When we're doing it",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Update",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "What user data will be collected",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Privacy Policy",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -200,7 +200,7 @@
         "description": "FAQ answer to the question 'Does Psiphon for Windows work on Windows XP or Vista?'"
     },
     "faq-information-collected-answer-redirect": {
-        "message": "Veuillez consulter notre <a href=\"privacy.html\">politique de confidentialité</a> pour savoir quels renseignements nous recueillons.",
+        "message": "Veuillez consulter notre <a href=\"privacy.html\">Politique de confidentialité</a> pour savoir quels renseignements nous recueillons.",
         "description": "This is the FAQ answer to the question 'What info does Psiphon collect?' The user needs to go to a separate page to see the full answer."
     },
     "faq-ip-change-question": {
@@ -948,11 +948,11 @@
         "description": ""
     },
     "license-termination-terms-of-service-violations-header": {
-        "message": "Résiliation ; violations des conditions générales d’utilisation",
+        "message": "Résiliation ; violations des Conditions générales d’utilisation",
         "description": ""
     },
     "license-termination-terms-of-service-violations-para-1": {
-        "message": "Psiphon se réserve le droit, à sa discrétion, d’annuler cette licence à tout moment, pour une raison quelconque ou sans raison et sans pénalité. En utilisant Psiphon, vous acceptez de ne pas utiliser le service de façon à enfreindre les conditions générales d’utilisation et de licence.",
+        "message": "Psiphon se réserve le droit, à sa discrétion, d’annuler cette licence à tout moment, pour une raison quelconque ou sans raison et sans pénalité. En utilisant Psiphon, vous acceptez de ne pas utiliser le service de façon à enfreindre les Conditions générales d’utilisation et de licence.",
         "description": ""
     },
     "license-termination-terms-of-service-violations-para-2": {
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon est à code source ouvert",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Les clients Psiphon utilisent les composants à code source ouvert suivants :",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows :",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android :",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon est un logiciel à code source ouvert. Vous pouvez trouver notre code source sur GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "téléchargement télécharger",
@@ -1251,6 +1239,22 @@
         "message": "Quand nous le faisons",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Mise à jour",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "Ce qui s’est passé",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Résolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Quelles données utilisateur seront recueillies",
         "description": ""
@@ -1300,15 +1304,15 @@
         "description": ""
     },
     "privacy-bulletin-entry-2-title": {
-        "message": "01-06-2015 : mise à jour de la politique de confidentialité",
+        "message": "01-06-2015 : mise à jour de la Politique de confidentialité",
         "description": "Title for a privacy bulletin"
     },
     "privacy-bulletin-entry-2-what-doing": {
-        "message": "Nous mettons à jour notre <a href=\"privacy.html\">politique de confidentialité</a>. Cela comprend l’ajout de la réponse à la question de la FAQ « Quels renseignements Psiphon recueille-t-il ? ».",
+        "message": "Nous mettons à jour notre <a href=\"privacy.html\">Politique de confidentialité</a>. Cela comprend l’ajout de la réponse à la question de la FAQ « Quels renseignements Psiphon recueille-t-il ? ».",
         "description": "A section of a privacy bulletin, indicating what is occurring that necessitates the bulletin"
     },
     "privacy-bulletin-entry-2-why-doing": {
-        "message": "La page de la <a href=\"privacy.html\">politique de confidentialité</a> est maintenant le seul endroit que les utilisateurs ont besoin de visiter pour accéder à la politique de confidentialité et de collecte des données de Psiphon. Elle a été mise à jour afin de refléter l’utilisation de publicités, d’analytique et de la journalisation pour certains de nos sites Web.",
+        "message": "La page de la <a href=\"privacy.html\">Politique de confidentialité</a> est maintenant le seul endroit que les utilisateurs ont besoin de visiter pour accéder à la Politique de confidentialité et de collecte des données de Psiphon. Elle a été mise à jour afin de refléter l’utilisation de publicités, d’analytique et de la journalisation pour certains de nos sites Web.",
         "description": "A section of a privacy bulletin, giving the reason for the change that necessitates the bulletin"
     },
     "privacy-bulletin-entry-2-when-doing": {
@@ -1316,15 +1320,15 @@
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
     },
     "privacy-bulletin-entry-3-title": {
-        "message": "11-12-2019 : Mise à jour de la politique de confidentialité",
+        "message": "11-12-2019 : Mise à jour de la Politique de confidentialité",
         "description": "Title for a privacy bulletin"
     },
     "privacy-bulletin-entry-3-what-doing": {
-        "message": "Nous mettons à jour notre <a href=\"privacy.html\">politique de confidentialité</a>. Nous passons la période de rétention des données d’activités des utilisateurs de 60 à 90 jours. Nous avons aussi augmenté les renseignements au sujet des bulletins sur la protection des données personnelles. Pour connaître les changements exacts, veuillez consulter l’<a target=\"_blank\" href=\"https://github.com/Psiphon-Inc/psiphon-website/commit/3327279e65aa5929ea50379f74a85aab3a69c8bf\">archivage GitHub</a> (page en anglais).",
+        "message": "Nous mettons à jour notre <a href=\"privacy.html\">Politique de confidentialité</a>. Nous passons la période de rétention des données d’activités des utilisateurs de 60 à 90 jours. Nous avons aussi augmenté les renseignements au sujet des bulletins sur la protection des données personnelles. Pour connaître les changements exacts, veuillez consulter l’<a target=\"_blank\" href=\"https://github.com/Psiphon-Inc/psiphon-website/commit/3327279e65aa5929ea50379f74a85aab3a69c8bf\">archivage GitHub</a> (page en anglais).",
         "description": "A section of a privacy bulletin, indicating what is occurring that necessitates the bulletin"
     },
     "privacy-bulletin-entry-3-why-doing": {
-        "message": "Pour garantir que la politique de confidentialité traduit fidèlement nos pratiques en matière de données.",
+        "message": "Pour garantir que la Politique de confidentialité traduit fidèlement nos pratiques en matière de données.",
         "description": "A section of a privacy bulletin, giving the reason for the change that necessitates the bulletin"
     },
     "privacy-bulletin-entry-3-when-doing": {
@@ -1347,6 +1351,26 @@
         "message": "L’entrée en vigueur sera le 12-12-2019 à minuit, pour une période d’un mois. Nous mettrons ce bulletin à jour si la mesure doit être prorogée.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
     },
+    "privacy-bulletin-entry-4-update": {
+        "message": "La conservation des données d’activité des utilisateurs était retournée à la normale le 10-04-2020.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "16-06-2020 : exception de confidentialité : conservation accidentelle des IP utilisateurs",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "Nous utilisons ASW S3 pour héberger les sites Web, les applications client, ainsi que les listes de serveurs distants. Nous avons découvert que la journalisation était activée pour plusieurs de nos ressources S3 depuis juin 2015. Ces journaux comprennent les adresses IP d’utilisateurs qui ont accédé à ces ressources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "Nous n’avons aucune indication que ces journaux est été obtenus par des tiers externes. Cependant, cela représente un non-respect de notre Politique de confidentialité.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "La journalisation a été désactivée pour les compartiments S3 accessibles par les utilisateurs et les journaux ont été supprimés. Nous travaillons sur un système de suivi des exceptions et problèmes de confidentialité, et examinons l’audit des ressources AWS.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
+    },
     "privacy-title": {
         "message": "Politique de confidentialité",
         "description": "page title for the Privacy Policy page"
@@ -1364,7 +1388,7 @@
         "description": "description for the Privacy Policy page"
     },
     "privacy-para-1": {
-        "message": "Psiphon est déterminé à protéger la confidentialité de ces clients, de ces utilisateurs finals, de ces distributeurs et de ces fournisseurs. Cette politique de confidentialité vise à vous donner des renseignements généraux sur l’utilisation potentielle de vos renseignements personnels. Psiphon est une société canadienne dont le siège social est situé en Ontario et notre politique de confidentialité a été développée pour refléter les lois et statuts canadiens et ontariens sur la protection des renseignements personnels.",
+        "message": "Psiphon est déterminé à protéger la confidentialité de ces clients, de ces utilisateurs finals, de ces distributeurs et de ces fournisseurs. Cette Politique de confidentialité vise à vous donner des renseignements généraux sur l’utilisation potentielle de vos renseignements personnels. Psiphon est une société canadienne dont le siège social est situé en Ontario et notre Politique de confidentialité a été développée pour refléter les lois et statuts canadiens et ontariens sur la protection des renseignements personnels.",
         "description": ""
     },
     "privacy-para-2": {
@@ -1388,11 +1412,11 @@
         "description": "Paragraph introducing a bullet list."
     },
     "privacy-bulletin-info-para-2-item-1": {
-        "message": "Nous modifions la politique de confidentialité. Cela peut arriver quand de nouvelles lois ajoutent des exigences différentes ou si nous commençons ou cessons d’utiliser un service tiers. Nous expliquerons en détail les changements apportés à la politique.",
+        "message": "Nous modifions la Politique de confidentialité. Cela peut arriver quand de nouvelles lois ajoutent des exigences différentes ou si nous commençons ou cessons d’utiliser un service tiers. Nous expliquerons en détail les changements apportés à la politique.",
         "description": "A bullet list item following from 'This will happen for two reasons:'"
     },
     "privacy-bulletin-info-para-2-item-2": {
-        "message": "Nous dérogeons temporairement à notre politique de confidentialité en changeant notre approche de collecte de renseignements. Cela se fait généralement pour résoudre un problème avec notre service ou pour nous donner plus de temps afin d’analyser nos données relatives à un événement de censure intéressant. Nous décrirons le changement, par exemple ce qui a été enregistré, la période de rétention et la raison.",
+        "message": "Nous dérogeons temporairement à notre Politique de confidentialité en changeant notre approche de collecte de renseignements. Cela se fait généralement pour résoudre un problème avec notre service ou pour nous donner plus de temps afin d’analyser nos données relatives à un événement de censure intéressant. Nous décrirons le changement, par exemple ce qui a été enregistré, la période de rétention et la raison.",
         "description": "A bullet list item following from 'This will happen for two reasons:'"
     },
     "faq-information-collected-question": {
@@ -1428,7 +1452,7 @@
         "description": ""
     },
     "privacy-information-collected-websites-google-analytics-para-3": {
-        "message": "La capacité de Google à utiliser et à partager les renseignements recueillis par l’analytique Google sur vos visites de ce site est restreinte par <a href=\"http://www.google.com/analytics/terms/fr.html\" target=\"_blank\">les conditions d’utilisation de l’analytique Google</a> et la <a href=\"https://www.google.ca/intl/fr/policies/privacy/\" target=\"_blank\">politique de confidentialité de Google</a>. Vous pouvez choisir l’option d’exclusion en désactivant les témoins dans les paramètres de préférence de votre navigateur Web.",
+        "message": "La capacité de Google à utiliser et à partager les renseignements recueillis par l’analytique Google sur vos visites de ce site est restreinte par <a href=\"http://www.google.com/analytics/terms/fr.html\" target=\"_blank\">les conditions d’utilisation de l’analytique Google</a> et la <a href=\"https://www.google.ca/intl/fr/policies/privacy/\" target=\"_blank\">Politique de confidentialité de Google</a>. Vous pouvez choisir l’option d’exclusion en désactivant les témoins dans les paramètres de préférence de votre navigateur Web.",
         "description": ""
     },
     "privacy-information-collected-s3-logging-head": {
@@ -1551,8 +1575,8 @@
         "message": "Un exemple de données d’activité d’un utilisateur pourrait être : à une certaine heure, un utilisateur s’est connecté de New York, en utilisant Comcast et a transféré 100 Mo de <code>youtube.com</code>, pour un total de 300 Mo.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "Nous considérons les données d’activités des utilisateurs comme étant la catégorie de données la plus délicate. Jamais nous ne partageons ces données avec des tiers. Nous conservons les données d’activités des utilisateurs 60 jours au maximum et nous les agrégeons ensuite puis les supprimons. Des sauvegardes de ces données sont conservées pour un temps raisonnable.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "Nous considérons les données d’activités des utilisateurs comme étant la catégorie de données la plus délicate. Jamais nous ne partageons ces données avec des tiers. Nous conservons les données d’activités des utilisateurs 90 jours au maximum et nous les agrégeons ensuite, puis les supprimons. Des sauvegardes de ces données sont conservées pour un temps raisonnable.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -16,7 +16,7 @@
         "description": "Slogan text that appears below the hero image on the main page. Should be in all lower-case, as it will be shown with 'small caps' -- but if that doesn't make sense in your language, feel free to use mixed case."
     },
     "index-hero-alt": {
-        "message": "Psiphon (سائفن)",
+        "message": "Psiphon",
         "description": "Alt text for hero image that appears on main page and says 'Psiphon' in a stylized font"
     },
     "nav-language-title": {
@@ -24,19 +24,19 @@
         "description": ""
     },
     "nav-title": {
-        "message": "Navigation",
+        "message": "ניווט",
         "description": ""
     },
     "faq-title": {
-        "message": "Frequently Asked Questions",
+        "message": "שאלות ותשובות שכיחות",
         "description": "title for the FAQ page"
     },
     "faq-meta-title": {
-        "message": "Frequently Asked Questions",
+        "message": "שאלות ותשובות שכיחות",
         "description": "meta title for the FAQ page"
     },
     "faq-nav-title": {
-        "message": "FAQ",
+        "message": "שאלות נפוצות",
         "description": "text for the FAQ page navigation item"
     },
     "faq-description": {
@@ -44,7 +44,7 @@
         "description": "description for the FAQ page"
     },
     "resources-nav-title": {
-        "message": "Resources",
+        "message": "משאבים",
         "description": "title for the Resources"
     },
     "user-guide-title": {
@@ -56,7 +56,7 @@
         "description": "meta title for the user guide page"
     },
     "user-guide-nav-title": {
-        "message": "User Guide",
+        "message": "מדריך למתחיל",
         "description": "text for the user guide page navigation item"
     },
     "user-guide-description": {
@@ -64,7 +64,7 @@
         "description": "description for the user guide page"
     },
     "download-title": {
-        "message": "Psiphon (سائفن) ڈاؤن لوڈ کریں",
+        "message": "Download Psiphon",
         "description": "page title for the download page"
     },
     "download-meta-title": {
@@ -72,7 +72,7 @@
         "description": "meta title for the download page"
     },
     "download-nav-title": {
-        "message": "ڈاؤن لوڈ کریں",
+        "message": "הורד",
         "description": "text for the Download page navigation item"
     },
     "download-description": {
@@ -96,7 +96,7 @@
         "description": "Section heading for FAQ entries that pertain to explaining how Psiphon works -- that is, how it helps users to circumvent/bypass censorship."
     },
     "faq-section-troubleshooting": {
-        "message": "Troubleshooting",
+        "message": "פתרון תקלות",
         "description": "Section heading for FAQ entries that help the user figure out why Psiphon isn't working for them and solve the problem."
     },
     "faq-subsection-troubleshooting-android": {
@@ -540,7 +540,7 @@
         "description": ""
     },
     "what-is-psiphon-body-para-2": {
-        "message": "Psiphon سائفن کو آپ کیلئے آن لائن مواد کی کھلی رسائی کیساتھ فراہمی کے سلسلے میں ترتیب دیا گیا ہے۔ Psiphon آپ کی آن لائن پرائیویسی کو نہیں بڑھاتا اور اس کا استعمال کسی آن لائن حفاظتی ٹول کے طور پر نہیں کیا جانا چاہئے۔",
+        "message": "Psiphon is designed to provide you with open access to online content. Psiphon does not increase your online privacy, and should not be considered or used as an online security tool.",
         "description": ""
     },
     "main-gets-you-where-you-want-head-1": {
@@ -576,15 +576,15 @@
         "description": ""
     },
     "about-title": {
-        "message": "About Us",
+        "message": "אודות",
         "description": "page title for the About page"
     },
     "about-meta-title": {
-        "message": "About Us",
+        "message": "אודות",
         "description": "meta title for the About page"
     },
     "about-nav-title": {
-        "message": "About Us",
+        "message": "אודות",
         "description": "text for the About page navigation item"
     },
     "about-description": {
@@ -612,7 +612,7 @@
         "description": "text for link to the Psiphon Developers mailing list"
     },
     "download-windows-direct": {
-        "message": "ونڈوز کیلئے Psiphon (سائفن)",
+        "message": "Psiphon for Windows",
         "description": "text for link to Psiphon for Windows download"
     },
     "download-windows-direct-description-v2": {
@@ -620,19 +620,19 @@
         "description": "Descriptive text on the download page indicating what versions of Windows Psiphon does and does not support. Windows XP and Vista are no longer supported, but there is an old (legacy) build available for download."
     },
     "download-android-direct": {
-        "message": "اینڈرائیڈ کیلئے Psiphon (سائفن) براہِ راست ڈاؤن لوڈ کریں",
+        "message": "Psiphon for Android direct download",
         "description": "text for link to Psiphon for Android direct download"
     },
     "download-android-direct-description": {
-        "message": "اگر آپ Google Play Store تک رسائی نہیں رکھتے تو آپ اینڈرائیڈ کیلئے براہِ راست Psiphon (سائفن) (’’<a href=\"https://en.wikipedia.org/wiki/Sideloading\" target=\"_blank\">سائیڈ لوڈ</a>‘‘) ڈاؤن لوڈ اور انسٹال کر سکتے ہیں۔",
+        "message": "If you do not have access to the Google Play Store, you can download and install (\"<a href=\"https://en.wikipedia.org/wiki/Sideloading\" target=\"_blank\">sideload</a>\") Psiphon for Android directly.",
         "description": ""
     },
     "download-android-playstore-pro": {
-        "message": "Google Play Store میں <strong>اینڈرائیڈ کیلئے  Psiphon Pro (سائفن پرو)</strong>",
+        "message": "<strong>Psiphon Pro for Android</strong> in the Google Play Store",
         "description": "Text for link to Psiphon Pro for Android in the Google Play Store. Psiphon Pro is supported by ads or subscription."
     },
     "download-android-playstore-pro-description": {
-        "message": "گوگل پلے سٹور سے Psiphon Pro (سائفن پرو) ڈاؤن لوڈ کر کے <strong>آزادئ انٹرنیٹ کی حمایت کریں</strong>۔ (تمام ممالک میں دستیاب نہیں) ",
+        "message": "<strong>Support Internet freedom</strong> by downloading Psiphon Pro from the Google Play Store. (Not available in all countries.)",
         "description": ""
     },
     "download-android-amazon": {
@@ -644,39 +644,39 @@
         "description": ""
     },
     "download-ios-appstore-psiphon-vpn": {
-        "message": "Apple App Store میں <strong>iOS کیلئے Psiphon (سائفن)</strong>",
+        "message": "<strong>Psiphon for iOS</strong> in the Apple App Store",
         "description": "Text for link to Psiphon for iOS in the Apple App Store. This is the 'whole device' version of Psiphon, as distinct from the 'Psiphon Browser' app."
     },
     "download-ios-appstore-psiphon-vpn-description": {
-        "message": "آپ کے آئی فون یا آئی پیڈ پر تمام ایپس Psiphon (سائفن) نیٹ ورک کے ذریعے انٹرنیٹ رسائی حاصل کریں گے۔ iOS 10.2 اور سے اوپر کی مشینوں کیلئے دستیاب ہے۔ ",
+        "message": "All of the apps on your iPhone or iPad will access the Internet through the Psiphon network. Available for iOS 10.2 and higher.",
         "description": "Description of Psiphon for iOS on the download page. Partly intended to distinguish 'Psiphon for iOS' from 'Psiphon Browser for iOS'."
     },
     "download-ios-appstore-psiphon-browser": {
-        "message": "Apple App Store میں <strong>iOS کیلئے Psiphon (سائفن) براؤزر</strong>",
+        "message": "<strong>Psiphon Browser for iOS</strong> in the Apple App Store",
         "description": "Text for link to Psiphon Browser for iOS in the Apple App Store. This app is distinct from the 'Psiphon for iOS' app that tunnels the whole device."
     },
     "download-ios-appstore-psiphon-browser-description": {
-        "message": "اپنے پسندیدہ ویب سائٹس اور سروسز تک Psiphon (سائفن) نیٹ ورک سے رسائی وہ بھی ہمارے استعمال میں کافی آسان ویب براؤزر کے ساتھ۔ یہ صرف iOS 8 یا اس سے اوپر کی مشینوں کیلئے دستیاب ہے۔",
+        "message": "Access your favorite web sites and services through the Psiphon network with our easy-to-use web browser. Available for iOS 8 and higher.",
         "description": "Description of Psiphon Browser for iOS on the download page. Partly intended to distinguish 'Psiphon Browser for iOS' from 'Psiphon for iOS'."
     },
     "download-store-head": {
-        "message": "ایپ سٹور ڈاؤن لوڈز",
+        "message": "App Store Downloads",
         "description": "This refers to the Google Play Store, Amazon's AppStore, and any similar app stores"
     },
     "download-direct-head": {
-        "message": "براہِ راست ڈاؤن لوڈز",
+        "message": "Direct Downloads",
         "description": ""
     },
     "download-via-email-head": {
-        "message": "ڈاؤن لوڈ بذریعہ ای میل",
+        "message": "Download via Email",
         "description": ""
     },
     "download-via-email-description": {
-        "message": "اگر ہماری ویب سائٹ یا ڈاؤن لوڈ لنکس سنسر یا بلاک ہوجائیں تو آپ ای میل کے ذریعے ڈاؤن لوڈز بھیجنے کی درخواست کر سکتے ہیں۔",
+        "message": "If our website or download links are blocked or censored, you may request to have the downloads sent to you via email.",
         "description": ""
     },
     "download-list-join": {
-        "message": "حفاظتی مشاورت اور ضروری اعلانات کیلئے ہماری <a href=\"https://groups.google.com/group/psiphon3\" target=\"_blank\">اعلانیہ میلنگ لسٹ</a> میں شامل ہوں۔",
+        "message": "Join our <a href=\"https://groups.google.com/group/psiphon3\" target=\"_blank\">Announcements mailing list</a> for important announcements and security advisories.",
         "description": ""
     },
     "user-guide-android-head": {
@@ -780,7 +780,7 @@
         "description": "annotation for an image of the Psiphon's statistics view, pointing to the savings in received data due to compression"
     },
     "user-guide-windows-head": {
-        "message": "ونڈوز کیلئے Psiphon (سائفن)",
+        "message": "Psiphon for Windows",
         "description": "heading for the Android section of the User Guide"
     },
     "user-guide-windows-para-verify-authentic": {
@@ -788,7 +788,7 @@
         "description": ""
     },
     "user-guide-windows-para-1": {
-        "message": "کلائنٹ پروگرام ڈاؤن لوڈ کریں اور اسے چلائیں۔ جب آپ اسے چلائیں تو آپ کو یہ دیکھنا چاہئے ایک حفاظتی اشتہار چلے گا کہ یہ پروگرام  .Psiphon Inc(سائفن اِن کارپوریشن) کی منظور شدہ مصنوعات میں سے ہے۔",
+        "message": "Download the client program and run it. When you run it, you should see a security prompt showing that this program is a legitimate product of Psiphon Inc.",
         "description": ""
     },
     "user-guide-windows-para-2": {
@@ -840,7 +840,7 @@
         "description": ""
     },
     "blog-index-subscribe": {
-        "message": "Subscribe",
+        "message": "הירשם כמנוי",
         "description": ""
     },
     "blog-index-intro": {
@@ -872,7 +872,7 @@
         "description": "Page description for the Sponsorship page"
     },
     "sponsor-header-sponsored-by": {
-        "message": "سپانسر شدہ",
+        "message": "Sponsored by",
         "description": ""
     },
     "sponsor-banner-alt-text": {
@@ -900,7 +900,7 @@
         "description": ""
     },
     "license-nav-title": {
-        "message": "License",
+        "message": "רישיון",
         "description": ""
     },
     "license-para-1": {
@@ -916,7 +916,7 @@
         "description": ""
     },
     "license-terms-of-use-header": {
-        "message": "Terms of Use",
+        "message": "תנאיי שימוש",
         "description": ""
     },
     "license-terms-of-use-para": {
@@ -976,7 +976,7 @@
         "description": "List item under the 'Use of PsiCash' subsection of the License page. The essence of this item is that Psiphon may change what things -- like Speed Boost -- cost in PsiCash. 'PsiCash' should not be translated or transliterated."
     },
     "about-who-we-are-head": {
-        "message": "Who We Are",
+        "message": "מי אנחנו",
         "description": ""
     },
     "about-who-we-are-para-1": {
@@ -1024,7 +1024,7 @@
         "description": "There are more than 20 languages currently supported, so if your language has a better fit than 'dozens', please use it. You can also just use something more generic, like 'many'."
     },
     "about-contact-head": {
-        "message": "Contact Us",
+        "message": "צור קשר",
         "description": ""
     },
     "contact-email-para": {
@@ -1048,15 +1048,15 @@
         "description": "The body of the page section that shows the donation buttons"
     },
     "open-source-title": {
-        "message": "Open Source",
+        "message": "מקור פתוח",
         "description": ""
     },
     "open-source-meta-title": {
-        "message": "Open Source",
+        "message": "מקור פתוח",
         "description": ""
     },
     "open-source-nav-title": {
-        "message": "Open Source",
+        "message": "מקור פתוח",
         "description": ""
     },
     "open-source-description": {
@@ -1068,7 +1068,7 @@
         "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
-        "message": "ڈاؤن لوڈ",
+        "message": "הורדה",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-vpn": {
@@ -1088,11 +1088,11 @@
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-censorship": {
-        "message": "censorship",
+        "message": "צנזורה",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-circumvention": {
-        "message": "circumvention",
+        "message": "עקיפה",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-psiphon3": {
@@ -1156,7 +1156,7 @@
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-contact": {
-        "message": "contact",
+        "message": "צור קשר",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-privacy": {
@@ -1196,7 +1196,7 @@
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-donate": {
-        "message": "donate",
+        "message": "תרום",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-contribute": {
@@ -1240,7 +1240,7 @@
         "description": ""
     },
     "privacy-bulletin-entry-item-head-update": {
-        "message": "اپ ڈیٹ کریں",
+        "message": "עדכן",
         "description": "This is a header for text that is an update to an existing privacy bulletin."
     },
     "privacy-bulletin-entry-item-head-what-happened": {
@@ -1372,15 +1372,15 @@
         "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
-        "message": "Privacy Policy",
+        "message": "מדיניות פרטיות",
         "description": "page title for the Privacy Policy page"
     },
     "privacy-meta-title": {
-        "message": "Privacy Policy",
+        "message": "מדיניות פרטיות",
         "description": "meta title for the Privacy Policy page"
     },
     "privacy-nav-title": {
-        "message": "Privacy Policy",
+        "message": "מדיניות פרטיות",
         "description": "text for the Privacy Policy page navigation item"
     },
     "privacy-description": {
@@ -1520,7 +1520,7 @@
         "description": "Sub-heading on the Privacy Policy page for the section describing handling of user traffic data and activity statistics through the Psiphon VPN"
     },
     "privacy-information-collected-vpndata-whycare-subhead": {
-        "message": "Why should you care?",
+        "message": "למה צריך להיות לך אכפת?",
         "description": "Sub-heading in the 'User Activity and VPN Data' section of the Privacy Policy page. The section describes why it's important for users to consider what a VPN does with their traffic data."
     },
     "privacy-information-collected-vpndata-whycare-para-1": {
@@ -1636,7 +1636,7 @@
         "description": "Bullet list text under 'What does Psiphon do with User Activity and Aggregated Data?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whydoespsiphonneed-para-1-item-1": {
-        "message": "Estimate future costs: The huge amount of user data we transfer each month is a major factor in our costs. It is vital for us to see and understand usage fluctuations.",
+        "message": "עלויות עתידיות משוערות: הכמות הענקית של נתוני משתמש שאנחנו מעבירים כל חודש היא גורם עיקרי בעלויות שלנו. זה חיוני בשבילנו לראות ולהבין תנודות שימוש.",
         "description": "Bullet list text under 'What does Psiphon do with User Activity and Aggregated Data?' subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-whydoespsiphonneed-para-1-item-3": {
@@ -1740,7 +1740,7 @@
         "description": "Paragraph text in the 'PsiCash' section of the Privacy page. 'PsiCash' must not be translated or transliterated."
     },
     "faq-information-collected-answer-head-2": {
-        "message": "آراؑ",
+        "message": "משוב",
         "description": ""
     },
     "faq-information-collected-answer-para-6": {
@@ -1828,7 +1828,7 @@
         "description": ""
     },
     "psiphon": {
-        "message": "Psiphon (سائفن)",
+        "message": "Psiphon",
         "description": "The name of the product. Probably not translated or transliterated for most languages"
     }
 }

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -8,7 +8,7 @@
         "description": "Meta title for the index page"
     },
     "index-description": {
-        "message": "Psiphon is circumvention software for Windows and Mobile platforms that provides uncensored access to Internet content",
+        "message": "Psiphon Windows और Mobile प्लेटफ़ॉर्म के लिए परिधि सॉफ़्टवेयर है जो इंटरनेट सामग्री तक बिना सेंसर की पहुंच प्रदान करता है",
         "description": "Page description for the index page"
     },
     "index-hero-subtext": {
@@ -16,7 +16,7 @@
         "description": "Slogan text that appears below the hero image on the main page. Should be in all lower-case, as it will be shown with 'small caps' -- but if that doesn't make sense in your language, feel free to use mixed case."
     },
     "index-hero-alt": {
-        "message": "Psiphon (سائفن)",
+        "message": "साइफॉन",
         "description": "Alt text for hero image that appears on main page and says 'Psiphon' in a stylized font"
     },
     "nav-language-title": {
@@ -28,15 +28,15 @@
         "description": ""
     },
     "faq-title": {
-        "message": "Frequently Asked Questions",
+        "message": "अक्सर पूछे जाने वाले प्रश्न",
         "description": "title for the FAQ page"
     },
     "faq-meta-title": {
-        "message": "Frequently Asked Questions",
+        "message": "अक्सर पूछे जाने वाले प्रश्न",
         "description": "meta title for the FAQ page"
     },
     "faq-nav-title": {
-        "message": "FAQ",
+        "message": "सामान्य प्रश्न",
         "description": "text for the FAQ page navigation item"
     },
     "faq-description": {
@@ -56,7 +56,7 @@
         "description": "meta title for the user guide page"
     },
     "user-guide-nav-title": {
-        "message": "User Guide",
+        "message": "उपयोगकर्ता गाइड",
         "description": "text for the user guide page navigation item"
     },
     "user-guide-description": {
@@ -64,7 +64,7 @@
         "description": "description for the user guide page"
     },
     "download-title": {
-        "message": "Psiphon (سائفن) ڈاؤن لوڈ کریں",
+        "message": "Download Psiphon",
         "description": "page title for the download page"
     },
     "download-meta-title": {
@@ -72,7 +72,7 @@
         "description": "meta title for the download page"
     },
     "download-nav-title": {
-        "message": "ڈاؤن لوڈ کریں",
+        "message": "डाउनलोड",
         "description": "text for the Download page navigation item"
     },
     "download-description": {
@@ -540,7 +540,7 @@
         "description": ""
     },
     "what-is-psiphon-body-para-2": {
-        "message": "Psiphon سائفن کو آپ کیلئے آن لائن مواد کی کھلی رسائی کیساتھ فراہمی کے سلسلے میں ترتیب دیا گیا ہے۔ Psiphon آپ کی آن لائن پرائیویسی کو نہیں بڑھاتا اور اس کا استعمال کسی آن لائن حفاظتی ٹول کے طور پر نہیں کیا جانا چاہئے۔",
+        "message": "Psiphon is designed to provide you with open access to online content. Psiphon does not increase your online privacy, and should not be considered or used as an online security tool.",
         "description": ""
     },
     "main-gets-you-where-you-want-head-1": {
@@ -576,15 +576,15 @@
         "description": ""
     },
     "about-title": {
-        "message": "About Us",
+        "message": "हमारे बारे में",
         "description": "page title for the About page"
     },
     "about-meta-title": {
-        "message": "About Us",
+        "message": "हमारे बारे में",
         "description": "meta title for the About page"
     },
     "about-nav-title": {
-        "message": "About Us",
+        "message": "हमारे बारे में",
         "description": "text for the About page navigation item"
     },
     "about-description": {
@@ -612,7 +612,7 @@
         "description": "text for link to the Psiphon Developers mailing list"
     },
     "download-windows-direct": {
-        "message": "ونڈوز کیلئے Psiphon (سائفن)",
+        "message": "Psiphon for Windows",
         "description": "text for link to Psiphon for Windows download"
     },
     "download-windows-direct-description-v2": {
@@ -620,19 +620,19 @@
         "description": "Descriptive text on the download page indicating what versions of Windows Psiphon does and does not support. Windows XP and Vista are no longer supported, but there is an old (legacy) build available for download."
     },
     "download-android-direct": {
-        "message": "اینڈرائیڈ کیلئے Psiphon (سائفن) براہِ راست ڈاؤن لوڈ کریں",
+        "message": "Psiphon for Android direct download",
         "description": "text for link to Psiphon for Android direct download"
     },
     "download-android-direct-description": {
-        "message": "اگر آپ Google Play Store تک رسائی نہیں رکھتے تو آپ اینڈرائیڈ کیلئے براہِ راست Psiphon (سائفن) (’’<a href=\"https://en.wikipedia.org/wiki/Sideloading\" target=\"_blank\">سائیڈ لوڈ</a>‘‘) ڈاؤن لوڈ اور انسٹال کر سکتے ہیں۔",
+        "message": "If you do not have access to the Google Play Store, you can download and install (\"<a href=\"https://en.wikipedia.org/wiki/Sideloading\" target=\"_blank\">sideload</a>\") Psiphon for Android directly.",
         "description": ""
     },
     "download-android-playstore-pro": {
-        "message": "Google Play Store میں <strong>اینڈرائیڈ کیلئے  Psiphon Pro (سائفن پرو)</strong>",
+        "message": "<strong>Psiphon Pro for Android</strong> in the Google Play Store",
         "description": "Text for link to Psiphon Pro for Android in the Google Play Store. Psiphon Pro is supported by ads or subscription."
     },
     "download-android-playstore-pro-description": {
-        "message": "گوگل پلے سٹور سے Psiphon Pro (سائفن پرو) ڈاؤن لوڈ کر کے <strong>آزادئ انٹرنیٹ کی حمایت کریں</strong>۔ (تمام ممالک میں دستیاب نہیں) ",
+        "message": "<strong>Support Internet freedom</strong> by downloading Psiphon Pro from the Google Play Store. (Not available in all countries.)",
         "description": ""
     },
     "download-android-amazon": {
@@ -644,39 +644,39 @@
         "description": ""
     },
     "download-ios-appstore-psiphon-vpn": {
-        "message": "Apple App Store میں <strong>iOS کیلئے Psiphon (سائفن)</strong>",
+        "message": "<strong>Psiphon for iOS</strong> in the Apple App Store",
         "description": "Text for link to Psiphon for iOS in the Apple App Store. This is the 'whole device' version of Psiphon, as distinct from the 'Psiphon Browser' app."
     },
     "download-ios-appstore-psiphon-vpn-description": {
-        "message": "آپ کے آئی فون یا آئی پیڈ پر تمام ایپس Psiphon (سائفن) نیٹ ورک کے ذریعے انٹرنیٹ رسائی حاصل کریں گے۔ iOS 10.2 اور سے اوپر کی مشینوں کیلئے دستیاب ہے۔ ",
+        "message": "All of the apps on your iPhone or iPad will access the Internet through the Psiphon network. Available for iOS 10.2 and higher.",
         "description": "Description of Psiphon for iOS on the download page. Partly intended to distinguish 'Psiphon for iOS' from 'Psiphon Browser for iOS'."
     },
     "download-ios-appstore-psiphon-browser": {
-        "message": "Apple App Store میں <strong>iOS کیلئے Psiphon (سائفن) براؤزر</strong>",
+        "message": "<strong>Psiphon Browser for iOS</strong> in the Apple App Store",
         "description": "Text for link to Psiphon Browser for iOS in the Apple App Store. This app is distinct from the 'Psiphon for iOS' app that tunnels the whole device."
     },
     "download-ios-appstore-psiphon-browser-description": {
-        "message": "اپنے پسندیدہ ویب سائٹس اور سروسز تک Psiphon (سائفن) نیٹ ورک سے رسائی وہ بھی ہمارے استعمال میں کافی آسان ویب براؤزر کے ساتھ۔ یہ صرف iOS 8 یا اس سے اوپر کی مشینوں کیلئے دستیاب ہے۔",
+        "message": "Access your favorite web sites and services through the Psiphon network with our easy-to-use web browser. Available for iOS 8 and higher.",
         "description": "Description of Psiphon Browser for iOS on the download page. Partly intended to distinguish 'Psiphon Browser for iOS' from 'Psiphon for iOS'."
     },
     "download-store-head": {
-        "message": "ایپ سٹور ڈاؤن لوڈز",
+        "message": "App Store Downloads",
         "description": "This refers to the Google Play Store, Amazon's AppStore, and any similar app stores"
     },
     "download-direct-head": {
-        "message": "براہِ راست ڈاؤن لوڈز",
+        "message": "Direct Downloads",
         "description": ""
     },
     "download-via-email-head": {
-        "message": "ڈاؤن لوڈ بذریعہ ای میل",
+        "message": "Download via Email",
         "description": ""
     },
     "download-via-email-description": {
-        "message": "اگر ہماری ویب سائٹ یا ڈاؤن لوڈ لنکس سنسر یا بلاک ہوجائیں تو آپ ای میل کے ذریعے ڈاؤن لوڈز بھیجنے کی درخواست کر سکتے ہیں۔",
+        "message": "If our website or download links are blocked or censored, you may request to have the downloads sent to you via email.",
         "description": ""
     },
     "download-list-join": {
-        "message": "حفاظتی مشاورت اور ضروری اعلانات کیلئے ہماری <a href=\"https://groups.google.com/group/psiphon3\" target=\"_blank\">اعلانیہ میلنگ لسٹ</a> میں شامل ہوں۔",
+        "message": "Join our <a href=\"https://groups.google.com/group/psiphon3\" target=\"_blank\">Announcements mailing list</a> for important announcements and security advisories.",
         "description": ""
     },
     "user-guide-android-head": {
@@ -780,7 +780,7 @@
         "description": "annotation for an image of the Psiphon's statistics view, pointing to the savings in received data due to compression"
     },
     "user-guide-windows-head": {
-        "message": "ونڈوز کیلئے Psiphon (سائفن)",
+        "message": "Psiphon for Windows",
         "description": "heading for the Android section of the User Guide"
     },
     "user-guide-windows-para-verify-authentic": {
@@ -788,7 +788,7 @@
         "description": ""
     },
     "user-guide-windows-para-1": {
-        "message": "کلائنٹ پروگرام ڈاؤن لوڈ کریں اور اسے چلائیں۔ جب آپ اسے چلائیں تو آپ کو یہ دیکھنا چاہئے ایک حفاظتی اشتہار چلے گا کہ یہ پروگرام  .Psiphon Inc(سائفن اِن کارپوریشن) کی منظور شدہ مصنوعات میں سے ہے۔",
+        "message": "Download the client program and run it. When you run it, you should see a security prompt showing that this program is a legitimate product of Psiphon Inc.",
         "description": ""
     },
     "user-guide-windows-para-2": {
@@ -832,7 +832,7 @@
         "description": ""
     },
     "blog-index-nav-title": {
-        "message": "Our Blog",
+        "message": "हमारा ब्लॉग",
         "description": "Text for the navigation bar link to the blog"
     },
     "blog-index-description": {
@@ -872,7 +872,7 @@
         "description": "Page description for the Sponsorship page"
     },
     "sponsor-header-sponsored-by": {
-        "message": "سپانسر شدہ",
+        "message": "Sponsored by",
         "description": ""
     },
     "sponsor-banner-alt-text": {
@@ -900,7 +900,7 @@
         "description": ""
     },
     "license-nav-title": {
-        "message": "License",
+        "message": "लाइसेंस",
         "description": ""
     },
     "license-para-1": {
@@ -1048,15 +1048,15 @@
         "description": "The body of the page section that shows the donation buttons"
     },
     "open-source-title": {
-        "message": "Open Source",
+        "message": "खुला स्त्रोत",
         "description": ""
     },
     "open-source-meta-title": {
-        "message": "Open Source",
+        "message": "खुला स्त्रोत",
         "description": ""
     },
     "open-source-nav-title": {
-        "message": "Open Source",
+        "message": "खुला स्त्रोत",
         "description": ""
     },
     "open-source-description": {
@@ -1068,7 +1068,7 @@
         "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
-        "message": "ڈاؤن لوڈ",
+        "message": "download",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-vpn": {
@@ -1140,7 +1140,7 @@
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-help": {
-        "message": "help",
+        "message": "सहायता",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-psiphon-team": {
@@ -1240,7 +1240,7 @@
         "description": ""
     },
     "privacy-bulletin-entry-item-head-update": {
-        "message": "اپ ڈیٹ کریں",
+        "message": "अद्यतन करें",
         "description": "This is a header for text that is an update to an existing privacy bulletin."
     },
     "privacy-bulletin-entry-item-head-what-happened": {
@@ -1372,15 +1372,15 @@
         "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
-        "message": "Privacy Policy",
+        "message": "गोपनीयता नीति",
         "description": "page title for the Privacy Policy page"
     },
     "privacy-meta-title": {
-        "message": "Privacy Policy",
+        "message": "गोपनीयता नीति",
         "description": "meta title for the Privacy Policy page"
     },
     "privacy-nav-title": {
-        "message": "Privacy Policy",
+        "message": "गोपनीयता नीति",
         "description": "text for the Privacy Policy page navigation item"
     },
     "privacy-description": {
@@ -1740,7 +1740,7 @@
         "description": "Paragraph text in the 'PsiCash' section of the Privacy page. 'PsiCash' must not be translated or transliterated."
     },
     "faq-information-collected-answer-head-2": {
-        "message": "آراؑ",
+        "message": "प्रतिक्रिया",
         "description": ""
     },
     "faq-information-collected-answer-para-6": {
@@ -1828,7 +1828,7 @@
         "description": ""
     },
     "psiphon": {
-        "message": "Psiphon (سائفن)",
+        "message": "साइफॉन",
         "description": "The name of the product. Probably not translated or transliterated for most languages"
     }
 }

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon klijenti koriste sljedeće otvorene komponente:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "preuzimanje",
@@ -1251,6 +1239,22 @@
         "message": "Kad to radimo",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Aktualiziraj",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Koji korisnički podatci će biti prikupljeni",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Izjava o privatnosti",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon adalah sumber terbuka.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Aplikasi klien Psiphon menggunakan komponen sumber terbuka berikut:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "unduh",
@@ -1251,6 +1239,22 @@
         "message": "Kapan kami melakukannya",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Perbarui",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Apa saja data pengguna yang akan kami kumpulkan",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "Ini akan mulai berlaku tanggal 2019-12-12T00:00Z. Ini akan berlangsung selama satu bulan. Kami akan memutakhirkan buletin ini apabila dibutuhkan untuk diperluas lagi.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Kebijakan Privasi",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -8,31 +8,31 @@
         "description": "Meta title for the index page"
     },
     "index-description": {
-        "message": "Psiphon is circumvention software for Windows and Mobile platforms that provides uncensored access to Internet content",
+        "message": "Psiphon è un software di protezione per le piattaforme Windows e Mobile che fornisce un accesso non censurato ai contenuti di Internet",
         "description": "Page description for the index page"
     },
     "index-hero-subtext": {
-        "message": "beyond borders",
+        "message": "oltre i limiti",
         "description": "Slogan text that appears below the hero image on the main page. Should be in all lower-case, as it will be shown with 'small caps' -- but if that doesn't make sense in your language, feel free to use mixed case."
     },
     "index-hero-alt": {
-        "message": "Psiphon (سائفن)",
+        "message": "Psiphon",
         "description": "Alt text for hero image that appears on main page and says 'Psiphon' in a stylized font"
     },
     "nav-language-title": {
-        "message": "Choose your language",
+        "message": "Scegli la tua lingua",
         "description": ""
     },
     "nav-title": {
-        "message": "Navigation",
+        "message": "Navigazione%",
         "description": ""
     },
     "faq-title": {
-        "message": "Frequently Asked Questions",
+        "message": "FAQ",
         "description": "title for the FAQ page"
     },
     "faq-meta-title": {
-        "message": "Frequently Asked Questions",
+        "message": "FAQ",
         "description": "meta title for the FAQ page"
     },
     "faq-nav-title": {
@@ -44,11 +44,11 @@
         "description": "description for the FAQ page"
     },
     "resources-nav-title": {
-        "message": "Resources",
+        "message": "Risorse",
         "description": "title for the Resources"
     },
     "user-guide-title": {
-        "message": "How to Use Psiphon",
+        "message": "Come usare Psiphon",
         "description": "page title for the user guide page"
     },
     "user-guide-meta-title": {
@@ -56,7 +56,7 @@
         "description": "meta title for the user guide page"
     },
     "user-guide-nav-title": {
-        "message": "User Guide",
+        "message": "Guida Utente",
         "description": "text for the user guide page navigation item"
     },
     "user-guide-description": {
@@ -64,7 +64,7 @@
         "description": "description for the user guide page"
     },
     "download-title": {
-        "message": "Psiphon (سائفن) ڈاؤن لوڈ کریں",
+        "message": "Scarica Psiphon",
         "description": "page title for the download page"
     },
     "download-meta-title": {
@@ -72,7 +72,7 @@
         "description": "meta title for the download page"
     },
     "download-nav-title": {
-        "message": "ڈاؤن لوڈ کریں",
+        "message": "Scaricamento",
         "description": "text for the Download page navigation item"
     },
     "download-description": {
@@ -96,7 +96,7 @@
         "description": "Section heading for FAQ entries that pertain to explaining how Psiphon works -- that is, how it helps users to circumvent/bypass censorship."
     },
     "faq-section-troubleshooting": {
-        "message": "Troubleshooting",
+        "message": "Risoluzione dei problemi",
         "description": "Section heading for FAQ entries that help the user figure out why Psiphon isn't working for them and solve the problem."
     },
     "faq-subsection-troubleshooting-android": {
@@ -120,7 +120,7 @@
         "description": "alt text for an image"
     },
     "faq-authentic-windows-question": {
-        "message": "Is my Psiphon for Windows authentic?",
+        "message": "Il mio Psiphon per Windows è autentico?",
         "description": ""
     },
     "faq-authentic-windows-answer-para-1": {
@@ -276,7 +276,7 @@
         "description": ""
     },
     "faq-check-version-answer-para-1": {
-        "message": "When Psiphon starts, it displays the Client Version on the first line of log output.",
+        "message": "All'avvio di Psiphon, visualizza la versione client sulla prima riga dell'output del registro.",
         "description": ""
     },
     "faq-get-updated-version-question": {
@@ -296,11 +296,11 @@
         "description": "FAQ answer to the question 'How do I get an updated version of Psiphon?' if the user believes that the automatic updating feature isn't working (or is blocked)."
     },
     "faq-orig-file-purpose-question": {
-        "message": "What is the file “psiphon3.exe.orig”?",
+        "message": "Cos'è il file “psiphon3.exe.orig”?",
         "description": ""
     },
     "faq-orig-file-purpose-answer-para-1": {
-        "message": "The automatic update process in Psiphon for Windows renames its old version to “psiphon3.exe.orig”. Old files with the “.orig” suffix can safely be deleted.",
+        "message": "Il processo di aggiornamento automatico in Psiphon per Windows, rinomina la vecchia versione in \"psiphon3.exe.orig\". I file obsoleti con estensione \".orig\", possono essere tranquillamente rimossi.",
         "description": ""
     },
     "faq-uninstall-windows-question": {
@@ -324,7 +324,7 @@
         "description": ""
     },
     "faq-proxy-all-answer-para-1": {
-        "message": "Only in VPN mode. After a successful connection is established in VPN mode, your entire computer’s traffic will pass through the Psiphon network. When VPN mode is not enabled only applications that use the local HTTP and SOCKS proxies will be proxied.",
+        "message": "Solo in modalità VPN. Stabilita una connessione in modalità VPN, tutto il traffico passa attraverso la rete Psiphon. Quando la modalità VPN non è abilitata solo le applicazioni che usano i proxy locali HTTP e SOCKS passano attraverso la rete Psiphon.",
         "description": ""
     },
     "faq-proxy-all-ios-browser-question": {
@@ -340,7 +340,7 @@
         "description": ""
     },
     "faq-browser-compatibility-answer-para-1": {
-        "message": "Yes. Check your browser settings and make sure that it is configured to use the system proxy settings.",
+        "message": "Sì. Verifica il tuo browser ed assicurati che sia configurato per usare il proxy di sistema.",
         "description": ""
     },
     "faq-port-restrictions-question": {
@@ -400,7 +400,7 @@
         "description": ""
     },
     "faq-vpn-protocol-answer-para-1": {
-        "message": "Psiphon uses the L2TP/IPsec VPN protocol.",
+        "message": "Psiphon usa i protocolli VPN L2TP/IPsec.",
         "description": ""
     },
     "faq-windows-vpn-connect-question": {
@@ -520,7 +520,7 @@
         "description": "This is the fourth paragraph of an FAQ answer."
     },
     "alert-heading": {
-        "message": "ALERT",
+        "message": "ALLARME",
         "description": "Heading of the alert that shows on the main page when there's a security or other concern that needs to be brought to the attention of users"
     },
     "alert-body": {
@@ -528,11 +528,11 @@
         "description": "Heading of the alert that shows on the main page when there's a security or other concern that needs to be brought to the attention of users"
     },
     "download-now-button": {
-        "message": "Download Now",
+        "message": "Scarica adesso",
         "description": "The text on the Download Now button"
     },
     "what-is-psiphon-heading": {
-        "message": "What is Psiphon?",
+        "message": "Cos'è Psiphon?",
         "description": ""
     },
     "what-is-psiphon-body-para-1": {
@@ -540,7 +540,7 @@
         "description": ""
     },
     "what-is-psiphon-body-para-2": {
-        "message": "Psiphon سائفن کو آپ کیلئے آن لائن مواد کی کھلی رسائی کیساتھ فراہمی کے سلسلے میں ترتیب دیا گیا ہے۔ Psiphon آپ کی آن لائن پرائیویسی کو نہیں بڑھاتا اور اس کا استعمال کسی آن لائن حفاظتی ٹول کے طور پر نہیں کیا جانا چاہئے۔",
+        "message": "Psiphon is designed to provide you with open access to online content. Psiphon does not increase your online privacy, and should not be considered or used as an online security tool.",
         "description": ""
     },
     "main-gets-you-where-you-want-head-1": {
@@ -556,7 +556,7 @@
         "description": ""
     },
     "main-gets-you-there-safely-head-1": {
-        "message": "...and gets you there safely.",
+        "message": "...e ti porterà al sicuro.",
         "description": ""
     },
     "main-gets-you-there-safely-head-2": {
@@ -568,7 +568,7 @@
         "description": ""
     },
     "main-pick-three-head-1": {
-        "message": "Trust, Speed, Simplicity: pick three",
+        "message": "Affidabilità, velocità. semplicità: 3 in 1",
         "description": ""
     },
     "main-pick-three-para-1": {
@@ -576,15 +576,15 @@
         "description": ""
     },
     "about-title": {
-        "message": "About Us",
+        "message": "Informazioni su di noi",
         "description": "page title for the About page"
     },
     "about-meta-title": {
-        "message": "About Us",
+        "message": "Informazioni su di noi",
         "description": "meta title for the About page"
     },
     "about-nav-title": {
-        "message": "About Us",
+        "message": "Informazioni su di noi",
         "description": "text for the About page navigation item"
     },
     "about-description": {
@@ -592,15 +592,15 @@
         "description": "description for the About page"
     },
     "about-get-latest-info-head": {
-        "message": "Get the latest information about Psiphon",
+        "message": "Ottieni le ultime informazioni su Psiphon",
         "description": ""
     },
     "about-get-latest-info-para-1-list-start": {
-        "message": "Join our mailing lists:",
+        "message": "Unisciti alla nostra lista di posta",
         "description": ""
     },
     "about-get-latest-info-para-1-announcements-list": {
-        "message": "Psiphon Announcements",
+        "message": "Annunci Psiphon",
         "description": "text for link to the Psiphon Announcements mailing list"
     },
     "about-get-latest-info-para-1-users-list": {
@@ -608,11 +608,11 @@
         "description": "text for link to the Psiphon Users mailing list"
     },
     "about-get-latest-info-para-1-developers-list": {
-        "message": "Psiphon Developers",
+        "message": "Sviluppatori Psiphon",
         "description": "text for link to the Psiphon Developers mailing list"
     },
     "download-windows-direct": {
-        "message": "ونڈوز کیلئے Psiphon (سائفن)",
+        "message": "Psiphon per Windows",
         "description": "text for link to Psiphon for Windows download"
     },
     "download-windows-direct-description-v2": {
@@ -620,19 +620,19 @@
         "description": "Descriptive text on the download page indicating what versions of Windows Psiphon does and does not support. Windows XP and Vista are no longer supported, but there is an old (legacy) build available for download."
     },
     "download-android-direct": {
-        "message": "اینڈرائیڈ کیلئے Psiphon (سائفن) براہِ راست ڈاؤن لوڈ کریں",
+        "message": "Scarica Psiphon per Android",
         "description": "text for link to Psiphon for Android direct download"
     },
     "download-android-direct-description": {
-        "message": "اگر آپ Google Play Store تک رسائی نہیں رکھتے تو آپ اینڈرائیڈ کیلئے براہِ راست Psiphon (سائفن) (’’<a href=\"https://en.wikipedia.org/wiki/Sideloading\" target=\"_blank\">سائیڈ لوڈ</a>‘‘) ڈاؤن لوڈ اور انسٹال کر سکتے ہیں۔",
+        "message": "In mancanza di accesso a Google Play Store, puoi scaricare ed installare Psiphon per Anfroid usando il (\"<a href=\"https://en.wikipedia.org/wiki/Sideloading\" target=\"_blank\">sideloading</a>\").",
         "description": ""
     },
     "download-android-playstore-pro": {
-        "message": "Google Play Store میں <strong>اینڈرائیڈ کیلئے  Psiphon Pro (سائفن پرو)</strong>",
+        "message": "<strong>Psiphon Pro for Android</strong> in the Google Play Store",
         "description": "Text for link to Psiphon Pro for Android in the Google Play Store. Psiphon Pro is supported by ads or subscription."
     },
     "download-android-playstore-pro-description": {
-        "message": "گوگل پلے سٹور سے Psiphon Pro (سائفن پرو) ڈاؤن لوڈ کر کے <strong>آزادئ انٹرنیٹ کی حمایت کریں</strong>۔ (تمام ممالک میں دستیاب نہیں) ",
+        "message": "<strong>Support Internet freedom</strong> by downloading Psiphon Pro from the Google Play Store. (Not available in all countries.)",
         "description": ""
     },
     "download-android-amazon": {
@@ -644,47 +644,47 @@
         "description": ""
     },
     "download-ios-appstore-psiphon-vpn": {
-        "message": "Apple App Store میں <strong>iOS کیلئے Psiphon (سائفن)</strong>",
+        "message": "<strong>Psiphon for iOS</strong> in the Apple App Store",
         "description": "Text for link to Psiphon for iOS in the Apple App Store. This is the 'whole device' version of Psiphon, as distinct from the 'Psiphon Browser' app."
     },
     "download-ios-appstore-psiphon-vpn-description": {
-        "message": "آپ کے آئی فون یا آئی پیڈ پر تمام ایپس Psiphon (سائفن) نیٹ ورک کے ذریعے انٹرنیٹ رسائی حاصل کریں گے۔ iOS 10.2 اور سے اوپر کی مشینوں کیلئے دستیاب ہے۔ ",
+        "message": "All of the apps on your iPhone or iPad will access the Internet through the Psiphon network. Available for iOS 10.2 and higher.",
         "description": "Description of Psiphon for iOS on the download page. Partly intended to distinguish 'Psiphon for iOS' from 'Psiphon Browser for iOS'."
     },
     "download-ios-appstore-psiphon-browser": {
-        "message": "Apple App Store میں <strong>iOS کیلئے Psiphon (سائفن) براؤزر</strong>",
+        "message": "<strong>Psiphon Browser for iOS</strong> in the Apple App Store",
         "description": "Text for link to Psiphon Browser for iOS in the Apple App Store. This app is distinct from the 'Psiphon for iOS' app that tunnels the whole device."
     },
     "download-ios-appstore-psiphon-browser-description": {
-        "message": "اپنے پسندیدہ ویب سائٹس اور سروسز تک Psiphon (سائفن) نیٹ ورک سے رسائی وہ بھی ہمارے استعمال میں کافی آسان ویب براؤزر کے ساتھ۔ یہ صرف iOS 8 یا اس سے اوپر کی مشینوں کیلئے دستیاب ہے۔",
+        "message": "Access your favorite web sites and services through the Psiphon network with our easy-to-use web browser. Available for iOS 8 and higher.",
         "description": "Description of Psiphon Browser for iOS on the download page. Partly intended to distinguish 'Psiphon Browser for iOS' from 'Psiphon for iOS'."
     },
     "download-store-head": {
-        "message": "ایپ سٹور ڈاؤن لوڈز",
+        "message": "App Store Downloads",
         "description": "This refers to the Google Play Store, Amazon's AppStore, and any similar app stores"
     },
     "download-direct-head": {
-        "message": "براہِ راست ڈاؤن لوڈز",
+        "message": "Download diretto",
         "description": ""
     },
     "download-via-email-head": {
-        "message": "ڈاؤن لوڈ بذریعہ ای میل",
+        "message": "Scarica via email",
         "description": ""
     },
     "download-via-email-description": {
-        "message": "اگر ہماری ویب سائٹ یا ڈاؤن لوڈ لنکس سنسر یا بلاک ہوجائیں تو آپ ای میل کے ذریعے ڈاؤن لوڈز بھیجنے کی درخواست کر سکتے ہیں۔",
+        "message": "If our website or download links are blocked or censored, you may request to have the downloads sent to you via email.",
         "description": ""
     },
     "download-list-join": {
-        "message": "حفاظتی مشاورت اور ضروری اعلانات کیلئے ہماری <a href=\"https://groups.google.com/group/psiphon3\" target=\"_blank\">اعلانیہ میلنگ لسٹ</a> میں شامل ہوں۔",
+        "message": "Join our <a href=\"https://groups.google.com/group/psiphon3\" target=\"_blank\">Announcements mailing list</a> for important announcements and security advisories.",
         "description": ""
     },
     "user-guide-android-head": {
-        "message": "Psiphon for Android",
+        "message": "Psiphon per Android",
         "description": "heading for the Android section of the User Guide"
     },
     "user-guide-android-para-verify-authentic": {
-        "message": "You should first <a href=\"./faq.html#authentic-android\">verify that your copy of Psiphon for Android is authentic</a>.",
+        "message": "Dovresti prima <a href=\"./faq.html#authentic-android\">verificare che la tua copia di Psiphon per Android sia autentica</a>.",
         "description": ""
     },
     "user-guide-android-para-1": {
@@ -708,15 +708,15 @@
         "description": "alt text for an image"
     },
     "user-guide-android-image-3-annotation-1": {
-        "message": "Psiphon is running",
+        "message": " Psiphon è in esecuzione",
         "description": "annotation for an image of the Psiphon built-in browser, pointing out the status icon that shows that Psiphon is running"
     },
     "user-guide-android-image-3-annotation-2": {
-        "message": "Switch between open tabs",
+        "message": "Commutare fra le schede aperte",
         "description": "annotation for an image of the Psiphon built-in browser, pointing to the button that switches between open tabs"
     },
     "user-guide-android-image-3-annotation-3": {
-        "message": "Close current tab",
+        "message": "Chiudere la scheda corrente",
         "description": "annotation for an image of the Psiphon built-in browser, pointing to the button that closes the current tab"
     },
     "user-guide-android-image-3-annotation-4": {
@@ -724,27 +724,27 @@
         "description": "annotation for an image of the Psiphon built-in browser, pointing to the button that bookmarks the current page"
     },
     "user-guide-android-image-3-annotation-5": {
-        "message": "Open new tab",
+        "message": "Apri una nuova scheda",
         "description": "annotation for an image of the Psiphon built-in browser, pointing to the button that opens a new tab"
     },
     "user-guide-android-ui-status-image-annotation-1": {
-        "message": "Psiphon is running in VPN or Whole Device mode. All applications are tunneled through Psiphon.",
+        "message": "Psiphon è in esecuzione in modalità VPN o Full Device. Tutte le applicazioni sono instradate attraverso Psiphon.",
         "description": "annotation for an image of the Psiphon's status view, pointing to the Psiphon icon in the Android notification area"
     },
     "user-guide-android-ui-status-image-annotation-2": {
-        "message": "Status Tab is selected",
+        "message": "Scheda di stato selezionata",
         "description": "annotation for an image of the Psiphon's status view, pointing to the highlighted Status tab"
     },
     "user-guide-android-ui-status-image-annotation-3": {
-        "message": "To run Psiphon in Tunnel Whole Device mode, you must have Android 4.0+ or a rooted device.<br><br>This option will be unavailable for non-rooted devices with an older version of Android.",
+        "message": "Per eseguire Psiphon in modalità Tunnel Whole Device, è necessario disporre di Android 4.0+ o di un dispositivo con permessi di root.<br><br> Questa opzione non sarà disponibile per i dispositivi no-root con una versione precedente di Android.",
         "description": "annotation for an image of the Psiphon's status view, pointing to the Tunnel Whole Device checkbox"
     },
     "user-guide-android-ui-status-image-annotation-4": {
-        "message": "<span style=\"color:grey\">Grey</span>: connecting<br><span style=\"color:red\">Red</span>: not connected<br><span style=\"color:Blue\">Blue</span>: connected",
+        "message": "<span style=\"color:grey\">Grigio</span>: connessione in corso<br><span style=\"color:red\">Rosso</span>: non connesso<br><span style=\"color:Blue\">Blu</span>: connesso",
         "description": "annotation for an image of the Psiphon's status view, pointing to the colored status icon in the middle of the Status panel"
     },
     "user-guide-android-ui-status-image-annotation-5": {
-        "message": "Shows what version of Psiphon you are currently running",
+        "message": "Mostra la versione di Psiphon attualmente in uso",
         "description": "annotation for an image of the Psiphon's status view, pointing to the currently running Psiphon version number"
     },
     "user-guide-android-ui-logs-image-alt": {
@@ -780,7 +780,7 @@
         "description": "annotation for an image of the Psiphon's statistics view, pointing to the savings in received data due to compression"
     },
     "user-guide-windows-head": {
-        "message": "ونڈوز کیلئے Psiphon (سائفن)",
+        "message": "Psiphon per Windows",
         "description": "heading for the Android section of the User Guide"
     },
     "user-guide-windows-para-verify-authentic": {
@@ -788,7 +788,7 @@
         "description": ""
     },
     "user-guide-windows-para-1": {
-        "message": "کلائنٹ پروگرام ڈاؤن لوڈ کریں اور اسے چلائیں۔ جب آپ اسے چلائیں تو آپ کو یہ دیکھنا چاہئے ایک حفاظتی اشتہار چلے گا کہ یہ پروگرام  .Psiphon Inc(سائفن اِن کارپوریشن) کی منظور شدہ مصنوعات میں سے ہے۔",
+        "message": "Download the client program and run it. When you run it, you should see a security prompt showing that this program is a legitimate product of Psiphon Inc.",
         "description": ""
     },
     "user-guide-windows-para-2": {
@@ -816,11 +816,11 @@
         "description": "alt text for an image"
     },
     "user-guide-windows-image-2-alt": {
-        "message": "Screenshot showing Psiphon starting up on Windows",
+        "message": "Schermata che mostra l'avvio di Psiphon su Windows",
         "description": "alt text for an image"
     },
     "user-guide-windows-image-3-alt": {
-        "message": "Screenshot showing Psiphon connected on Windows",
+        "message": "Schermata che mostra la connessione di Psiphon su Windows",
         "description": "alt text for an image"
     },
     "blog-index-title": {
@@ -832,7 +832,7 @@
         "description": ""
     },
     "blog-index-nav-title": {
-        "message": "Our Blog",
+        "message": "Blog",
         "description": "Text for the navigation bar link to the blog"
     },
     "blog-index-description": {
@@ -840,7 +840,7 @@
         "description": ""
     },
     "blog-index-subscribe": {
-        "message": "Subscribe",
+        "message": "Sottoscrivi",
         "description": ""
     },
     "blog-index-intro": {
@@ -848,11 +848,11 @@
         "description": ""
     },
     "blog-index-posts-in-your-language": {
-        "message": "Posts in your language",
+        "message": "Post nella tua lingua",
         "description": "TRANSLATORS NOTE: Please translate it as 'Posts in Farsi', 'Posts in Russian', etc. This is the heading for the list of blog posts that have been translated into the user's language."
     },
     "blog-index-posts-in-english": {
-        "message": "Posts in English",
+        "message": "Post in inglese",
         "description": "Heading for the list of blog posts that are available in English"
     },
     "sponsor-title": {
@@ -872,7 +872,7 @@
         "description": "Page description for the Sponsorship page"
     },
     "sponsor-header-sponsored-by": {
-        "message": "سپانسر شدہ",
+        "message": "Sponsorizzato da",
         "description": ""
     },
     "sponsor-banner-alt-text": {
@@ -880,11 +880,11 @@
         "description": "alt text for an image"
     },
     "sponsor-para-1": {
-        "message": "Everyone who loads Psiphon will see the landing page whenever they connect with the software. Sponsorship opportunities are available by the week for this page.",
+        "message": "Tutti coloro che avviano Psiphon vedranno la pagina di destinazione ogni volta che si connettono al software.. Le opportunità di sponsorizzazione per questa pagina, sono disponibili settiamanalmente.",
         "description": ""
     },
     "sponsor-para-2": {
-        "message": "You will see a banner of your choice, which will be linked to a page on your site. This is a unique opportunity to reach a large audience of technically-aware people using Psiphon to add a layer of security to their Internet browsing.",
+        "message": "Vedranno un banner a Vostra scelta, collegato ad una pagina del Vostro sito. Questa è un'opportunità unica per raggiungere un vasto pubblico di persone tecnicamente consapevoli, utilizzanti Psiphon per avere un livello di sicurezza superiore nella navigazione Internet.",
         "description": ""
     },
     "sponsor-para-3": {
@@ -892,7 +892,7 @@
         "description": ""
     },
     "license-title": {
-        "message": "Psiphon End-User License Agreement",
+        "message": "Contratto di licenza per l'utente Psiphon",
         "description": ""
     },
     "license-meta-title": {
@@ -900,7 +900,7 @@
         "description": ""
     },
     "license-nav-title": {
-        "message": "License",
+        "message": "Licenza",
         "description": ""
     },
     "license-para-1": {
@@ -916,7 +916,7 @@
         "description": ""
     },
     "license-terms-of-use-header": {
-        "message": "Terms of Use",
+        "message": "Termini di uso",
         "description": ""
     },
     "license-terms-of-use-para": {
@@ -924,7 +924,7 @@
         "description": ""
     },
     "license-distribution-header": {
-        "message": "Distribution",
+        "message": "Distribuzione",
         "description": ""
     },
     "license-distribution-para": {
@@ -936,7 +936,7 @@
         "description": ""
     },
     "license-personal-or-specified-use-para": {
-        "message": "Use of the Psiphon service is granted under a non-exclusive, personal license. By using Psiphon, you agree to use the service for personal, non-commercial use only. You may not (and may not allow a third party to) rent, lease, sublicense, sell, resell or otherwise distribute use of the Psiphon service for commercial purposes.",
+        "message": "L'uso del servizio Psiphon è garantito tramite licenza personale e non esclusiva. Con l'uso di Psiphon, accetti di utilizzare il servizio solo per uso personale e non commerciale. Non puoi (e non puoi permettere ad altri) di affittare, noleggiare, concedere in licenza, vendere, rivendere o comunque permettere un uso commerciale del servizio Psiphon.",
         "description": ""
     },
     "license-statement-of-limitations-of-liability-header": {
@@ -952,7 +952,7 @@
         "description": ""
     },
     "license-termination-terms-of-service-violations-para-1": {
-        "message": "Psiphon reserves the right at its sole discretion to terminate this license at any time for any or no reason, and without penalty. By using Psiphon, you agree not to use the service in any manner that violates the terms of service and license agreement.",
+        "message": "Psiphon si riserva il diritto esclusivo di revocare questa licenza in qualsiasi momento, per qualsiasi motivo o senza motivo e senza alcuna responsabilità. Utilizzando Psiphon, l'utente si impegna ad utilizzare il servizio senza violare i termini del servizio ed il contratto di licenza.",
         "description": ""
     },
     "license-termination-terms-of-service-violations-para-2": {
@@ -976,7 +976,7 @@
         "description": "List item under the 'Use of PsiCash' subsection of the License page. The essence of this item is that Psiphon may change what things -- like Speed Boost -- cost in PsiCash. 'PsiCash' should not be translated or transliterated."
     },
     "about-who-we-are-head": {
-        "message": "Who We Are",
+        "message": "Chi siamo",
         "description": ""
     },
     "about-who-we-are-para-1": {
@@ -984,7 +984,7 @@
         "description": ""
     },
     "about-who-we-are-exec-team-head": {
-        "message": "Exec Team",
+        "message": "Team Exec",
         "description": ""
     },
     "about-who-we-are-exec-team-para-1": {
@@ -992,7 +992,7 @@
         "description": ""
     },
     "about-who-we-are-software-development-head": {
-        "message": "Software Development",
+        "message": "Sviluppo Software",
         "description": ""
     },
     "about-who-we-are-software-development-para-1": {
@@ -1008,7 +1008,7 @@
         "description": ""
     },
     "about-who-we-are-ops-head": {
-        "message": "Operations and Outreach",
+        "message": "Operatività e diffusione",
         "description": ""
     },
     "about-who-we-are-ops-para-1": {
@@ -1016,7 +1016,7 @@
         "description": ""
     },
     "about-who-we-are-partners-head": {
-        "message": "Partnerships",
+        "message": "Collaborazioni",
         "description": ""
     },
     "about-who-we-are-partners-para-1": {
@@ -1024,7 +1024,7 @@
         "description": "There are more than 20 languages currently supported, so if your language has a better fit than 'dozens', please use it. You can also just use something more generic, like 'many'."
     },
     "about-contact-head": {
-        "message": "Contact Us",
+        "message": "Contattaci",
         "description": ""
     },
     "contact-email-para": {
@@ -1040,7 +1040,7 @@
         "description": "The beginning of the 'Licensed under [license name here]' footer text"
     },
     "donate-heading": {
-        "message": "Contribute to Psiphon",
+        "message": "Contribuisci a Psiphon",
         "description": "The heading of the page section that shows the donation buttons"
     },
     "donate-body": {
@@ -1068,159 +1068,159 @@
         "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
-        "message": "ڈاؤن لوڈ",
+        "message": "download",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-vpn": {
-        "message": "vpn",
+        "message": "VPN",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-ssh": {
-        "message": "ssh",
+        "message": "SSH",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-http-proxy": {
-        "message": "http proxy",
+        "message": "PROXY HTTP",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-proxy": {
-        "message": "proxy",
+        "message": "PROXY",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-censorship": {
-        "message": "censorship",
+        "message": "censura",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-circumvention": {
-        "message": "circumvention",
+        "message": "Elusione",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-psiphon3": {
-        "message": "psiphon3",
+        "message": "Psiphon3",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-android": {
-        "message": "android",
+        "message": "Android",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-windows": {
-        "message": "windows",
+        "message": "Windows",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-play-store": {
-        "message": "play store",
+        "message": "Play Store",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-app-store": {
-        "message": "app store",
+        "message": "App Store",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-psiphon1": {
-        "message": "psiphon1",
+        "message": "Psiphon1",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-psiphon2": {
-        "message": "psiphon2",
+        "message": "Psiphon2",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-user-guide": {
-        "message": "user guide",
+        "message": "Guida Utente",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-instructions": {
-        "message": "instructions",
+        "message": "Istruzioni",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-manual": {
-        "message": "manual",
+        "message": "Manuale",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-how-to": {
-        "message": "how to",
+        "message": "Come fare",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-help": {
-        "message": "help",
+        "message": "aiuto",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-psiphon-team": {
-        "message": "psiphon team",
+        "message": "Team Psiphon",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-developers": {
-        "message": "developers",
+        "message": "Sviluppatori",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-partnerships": {
-        "message": "partnerships",
+        "message": "Collaboratori",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-contact": {
-        "message": "contact",
+        "message": "contatti",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-privacy": {
-        "message": "privacy",
+        "message": "Privacy",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-blog": {
-        "message": "blog",
+        "message": "Blog",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-updates": {
-        "message": "updates",
+        "message": "Aggiornamenti",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-code": {
-        "message": "code",
+        "message": "Codice",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-development": {
-        "message": "development",
+        "message": "Sviluppo",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-open-source": {
-        "message": "open source",
+        "message": "Open Source",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-source-code": {
-        "message": "source code",
+        "message": "Codice Sorgente",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-advertise": {
-        "message": "advertise",
+        "message": "Pubblicizzare",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-sponsor": {
-        "message": "sponsor",
+        "message": "Sponsor",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-donate": {
-        "message": "donate",
+        "message": "dona",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-contribute": {
-        "message": "contribute",
+        "message": "Contribuisci",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-landing-page": {
-        "message": "landing page",
+        "message": "pagina di destinazione",
         "description": "web page meta keyword used for SEO"
     },
     "page-keyword-home-page": {
-        "message": "home page",
+        "message": "Home Page",
         "description": "web page meta keyword used for SEO"
     },
     "privacy-bulletin-title": {
-        "message": "Privacy Bulletins",
+        "message": "Bollettino Privacy",
         "description": ""
     },
     "privacy-bulletin-meta-title": {
-        "message": "Privacy Bulletins",
+        "message": "Bollettino Privacy",
         "description": ""
     },
     "privacy-bulletin-description": {
-        "message": "Privacy Bulletins",
+        "message": "Bollettino Privacy",
         "description": ""
     },
     "privacy-bulletin-intro-para-1": {
@@ -1228,11 +1228,11 @@
         "description": ""
     },
     "privacy-bulletin-entry-item-head-what-doing": {
-        "message": "What we're doing",
+        "message": "Cosa stiamo facendo",
         "description": ""
     },
     "privacy-bulletin-entry-item-head-why-doing": {
-        "message": "Why we're doing it",
+        "message": "Perché lo stiamo facendo",
         "description": ""
     },
     "privacy-bulletin-entry-item-head-when-doing": {
@@ -1240,7 +1240,7 @@
         "description": ""
     },
     "privacy-bulletin-entry-item-head-update": {
-        "message": "اپ ڈیٹ کریں",
+        "message": "Aggiorna",
         "description": "This is a header for text that is an update to an existing privacy bulletin."
     },
     "privacy-bulletin-entry-item-head-what-happened": {
@@ -1372,19 +1372,19 @@
         "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
-        "message": "Privacy Policy",
+        "message": "Politica di Privacy",
         "description": "page title for the Privacy Policy page"
     },
     "privacy-meta-title": {
-        "message": "Privacy Policy",
+        "message": "Politica di Privacy",
         "description": "meta title for the Privacy Policy page"
     },
     "privacy-nav-title": {
-        "message": "Privacy Policy",
+        "message": "Politica di Privacy",
         "description": "text for the Privacy Policy page navigation item"
     },
     "privacy-description": {
-        "message": "Psiphon's privacy policy",
+        "message": "Politica di Privacy di Psiphon",
         "description": "description for the Privacy Policy page"
     },
     "privacy-para-1": {
@@ -1404,7 +1404,7 @@
         "description": ""
     },
     "privacy-updates-head": {
-        "message": "Updates",
+        "message": "Aggiornamenti",
         "description": "Heading for a section in our privacy policy. The section description how we handle updates to the policy."
     },
     "privacy-bulletin-info-para-1": {
@@ -1468,7 +1468,7 @@
         "description": ""
     },
     "faq-information-collected-answer-head-1": {
-        "message": "Psiphon Servers",
+        "message": "Server Psiphon",
         "description": ""
     },
     "faq-information-collected-answer-para-1": {
@@ -1480,7 +1480,7 @@
         "description": ""
     },
     "faq-information-collected-answer-para-2-item-2": {
-        "message": "Number of upgrades",
+        "message": "Numero di aggiornamenti",
         "description": ""
     },
     "faq-information-collected-answer-para-2-item-3": {
@@ -1740,7 +1740,7 @@
         "description": "Paragraph text in the 'PsiCash' section of the Privacy page. 'PsiCash' must not be translated or transliterated."
     },
     "faq-information-collected-answer-head-2": {
-        "message": "آراؑ",
+        "message": "Commento",
         "description": ""
     },
     "faq-information-collected-answer-para-6": {
@@ -1752,11 +1752,11 @@
         "description": ""
     },
     "faq-information-collected-answer-para-7-item-1": {
-        "message": "Operating system version",
+        "message": "Versione sistema operativo",
         "description": ""
     },
     "faq-information-collected-answer-para-7-item-2": {
-        "message": "Anti-virus version",
+        "message": "Versione antivirus",
         "description": ""
     },
     "faq-information-collected-answer-para-7-item-3": {
@@ -1772,11 +1772,11 @@
         "description": ""
     },
     "faq-information-collected-answer-para-8-item-1": {
-        "message": "Android version",
+        "message": "Versione Android",
         "description": ""
     },
     "faq-information-collected-answer-para-8-item-2": {
-        "message": "Device model",
+        "message": "Modello dispositivo",
         "description": ""
     },
     "faq-information-collected-answer-para-8-item-3": {
@@ -1828,7 +1828,7 @@
         "description": ""
     },
     "psiphon": {
-        "message": "Psiphon (سائفن)",
+        "message": "Psiphon",
         "description": "The name of the product. Probably not translated or transliterated for most languages"
     }
 }

--- a/_locales/kk/messages.json
+++ b/_locales/kk/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon клиенттері келесі бастапқы кодтары ашық құрамдастарды қолданады:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "жүктеп алу",
@@ -1251,6 +1239,22 @@
         "message": "іске асырамыз",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Жаңарту",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Қандай пайдаланушы деректері жиналады",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Құпиялық саясаты",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/km/messages.json
+++ b/_locales/km/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "អតិថិជន Psiphon ប្រើសមាសភាគកូដបើកចំហខាងក្រោម:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows៖",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android៖",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "ទាញយក",
@@ -1251,6 +1239,22 @@
         "message": "នៅពេលយើងកំពុងធ្វើវា",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "បច្ចុប្បន្នភាព",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "អ្វីបានកើតឡើង",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "ផលប៉ះពាល់",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "ដំណោះស្រាយ",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "ទិន្នន័យអ្នកប្រើប្រាស់អ្វីខ្លះនឹងត្រូវប្រមូល",
         "description": ""
@@ -1328,7 +1332,7 @@
         "description": "A section of a privacy bulletin, giving the reason for the change that necessitates the bulletin"
     },
     "privacy-bulletin-entry-3-when-doing": {
-        "message": "This will be in effect on 2019-12-12T00:00Z.",
+        "message": "នេះនឹងចូលជាធរមាននៅ 2019-12-12T00:00Z។",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
     },
     "privacy-bulletin-entry-4-title": {
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "គោលការណ៍​ភាព​ឯកជន",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon 클라이언트는 다음과 같은 오픈 소스 구성요소를 사용합니다:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "다운로드",
@@ -1251,6 +1239,22 @@
         "message": "우리가 이걸 언제 하는지",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "업데이트",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "어떤 사용자 데이터가 수집되는가",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "개인 정보 보호 정책",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/ky/messages.json
+++ b/_locales/ky/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon клиенттери төмөнкү ачык булактагы компонентерди колдонушат:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "Жуктөлдү",
@@ -1251,6 +1239,22 @@
         "message": "Биз аны качан кылабыз",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Жаңыртуу",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Кандай колдонуучу берилмелерин топтойбуз",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Купуялык саясаты",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/my/messages.json
+++ b/_locales/my/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon သုံးစွဲသူများသည် အောက်ပါ ပွင့်လင်းအရင်းမြစ် အစိတ်အပိုင်းများကို အသုံးပြုသည် :",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "ဒေါင်းလုပ်",
@@ -1251,6 +1239,22 @@
         "message": "ကျွနု်ပ်တို့ ဘယ်အချိန်တွေမှာ ဒါကိုလုပ်သလဲ။",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "အဆင့္ျမွင့္တင္မည္။",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "အသုံးပြုသူ၏ မည်သည့် အချက်အလက်ကို ကောက်ယူထားမည်နည်း",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "ကိုယ်ရေးကိုယ်တာအချက်အလက်လုံခြုံရေး မူဝါဒ",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/nb/messages.json
+++ b/_locales/nb/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon-klienter bruker følgende friprog-komponenter:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "last ned",
@@ -1251,6 +1239,22 @@
         "message": "Når vi gjør det",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Oppdater",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Hvilken brukerdata vil bli innhentet",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Personverns-praksis",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon klanten gebruik dan de volgende open source componenten:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "download",
@@ -1251,6 +1239,22 @@
         "message": "Wanneer we doen het",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Bijwerken",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Wat gebruiker gegevens worden verzameld",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "privacybeleid",
@@ -1551,8 +1575,8 @@
         "message": "Een voorbeeld van gebruikersactiviteitsgegevens kan zijn: op een bepaald moment een gebruiker verbonden vanuit New York City, met behulp van Comcast, en 100 MB overgedragen van <code>youtube.com</code> en 300 MB in totaal.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/om/messages.json
+++ b/_locales/om/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon clients use the following open source components:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "download",
@@ -1251,6 +1239,22 @@
         "message": "When we're doing it",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Haromsi",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "What user data will be collected",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Qajeelfama Iccitii Dhuunfaa",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon clients use the following open source components:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "Baixar",
@@ -1251,6 +1239,22 @@
         "message": "When we're doing it",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Atualizar",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "What user data will be collected",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Política de Privacidade",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon clients use the following open source components:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "transferir",
@@ -1251,6 +1239,22 @@
         "message": "When we're doing it",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Atualizar",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "What user data will be collected",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Política de Privacidade",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "В клиентах Psiphon используются следующие компоненты с открытым исходным кодом:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "скачать",
@@ -1251,6 +1239,22 @@
         "message": "Когда мы делаем это",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Обновить",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Какие пользовательские данные собираются",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Политика конфиденциальности",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/tg/messages.json
+++ b/_locales/tg/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Нармафзори муштарии Psiphon қисмҳои зерини манбаи кушодро истифода мебаранд:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "боргирӣ кардан",
@@ -1251,6 +1239,22 @@
         "message": "Кай инро иҷро мекунем",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Навсозӣ кардан",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Кадом иттилооти корбарон ҷамъ карда мешавад",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Сиёсати махфият",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon clients use the following open source components:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "ดาวน์โหลด",
@@ -1251,6 +1239,22 @@
         "message": "When we're doing it",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "ปรับปรุง",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "What user data will be collected",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Privacy Policy",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/ti/messages.json
+++ b/_locales/ti/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon clients use the following open source components:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "download",
@@ -1251,6 +1239,22 @@
         "message": "When we're doing it",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "ምስ ግዜ ዝኸይድ ሓበሬታ ",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "What user data will be collected",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "ፖሊሲ መሰል ውልቃውነት",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/tk/messages.json
+++ b/_locales/tk/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon müşderileri aşakda görkezilen açyk çeşmeleri ullanýarlar:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "indir",
@@ -1251,6 +1239,22 @@
         "message": "Haçan edyäris",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Täzele",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": " Ulanyjy barada haýsy maglumatlar ýygnalýar?",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Gizlinlik Ugry",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon açık kaynaklıdır.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon istemcilerinde aşağıdaki açık kaynak bileşenleri kullanılmıştır:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon açık kaynaklı bir projedir. Kaynak kodunu GitHub üzerinde bulabilirsiniz.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "indir",
@@ -1251,6 +1239,22 @@
         "message": "Ne zaman yapıyoruz",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Güncelle",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "Ne oldu",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Etki",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Çözüm",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Hangi kullanıcı verileri toplanıyor",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "Bu uygulama 2019-12-12T00:00Z saatinde başlayarak bir ay süreyle geçerli olacaktır. Daha uzun süreye gerek duyduğumuzu anlarsak bu bülteni güncelleyeceğiz.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "Kullanıcı işlemi verilerini saklama süresi 2020-04-10 tarihinde normale döndürüldü.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Kişisel gizlilik sorunu: Kazara kullanıcı IP adresinin kaydedilmesi",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "Web sitelerini, istemci uygulamalarını ve uzak sunucu listelerini barındırmak için AWS S3 kullanıyoruz. Haziran 2015 tarihinden itibaren S3 kaynaklarımızın çoğunda günlük tutma özelliğinin etkin olduğunu farkettik. Bu günlüklerde bu kaynaklara erişen kullanıcıların IP adresleri bulunuyor.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "Herhangi bir günlüğün başka birinin eline geçtğine dair bir bulgu olmadığından kullanıcı bilgileri açığa çıkmış sayılmaz. Bununla birlikte bu durum Gizlilik İlkemize aykırı bir durum oluşturuyor.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Kullanıcılar tarafından erişilebilen S3 klasörleri için günlük kaydı özelliği devre dışı bırakıldı ve tüm günlükler silindi. Gizlilikle ilgili sorunları izlemek ve AWS kaynak denetimini araştırmak için bir sistem üzerinde çalışıyoruz.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Kişisel Gizlilik İlkesi",
@@ -1551,8 +1575,8 @@
         "message": "Örneğin kullanıcı işlemi verileri şöyle olabilir: Belirli bir zamanda bir kullanıcı Türk Telekom bağlantısını kullanarak Ankara'dan bağlandı ve <code>youtube.com</code> üzerinden aktarılan toplam 300MB verinin 100MB kadarını aktardı.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "Kullanıcı işlemleri verilerini en hassas veri kategorisi olarak değerlendiriyoruz. Bu verileri asla üçüncü şahıslarla paylaşmmıyoruz. Kullanıcı işlemleri verilerini en fazla 60 gün saklıyoruz, sonra sonuçlarını derleyip ham verileri siliyoruz. Bu verilerin yedeklerini makul bir süre boyunca saklıyoruz.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "Kullanıcı işlemleri verilerini en hassas veri kategorisi olarak değerlendiriyoruz. Bu verileri asla üçüncü şahıslarla paylaşmmıyoruz. Kullanıcı işlemleri verilerini en fazla 90 gün saklıyoruz, sonra sonuçlarını derleyip ham verileri siliyoruz. Bu verilerin yedeklerini makul bir süre boyunca saklıyoruz.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Клієнти Psiphon використовують такі компоненти з відкритим кодом:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "завантажити",
@@ -1251,6 +1239,22 @@
         "message": "Коли ми це робимо",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Оновити",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Які дані користувачів збиратимуться",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Політика конфіденційності",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/uz@Latn/messages.json
+++ b/_locales/uz@Latn/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon mijoz-dasturlari quyidagi ochiq kodli vositalardan iborat:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "yuklab olish",
@@ -1251,6 +1239,22 @@
         "message": "Qachon bunday qilyapmiz",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Yangilash",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Qanday foydalanuvchi ma’lumotlari yig‘ilmoqda",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Maxfiylik siyosati",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon dùng các thành phần nguồn mở sau đây:",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows:",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android:",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "Tải xuống",
@@ -1251,6 +1239,22 @@
         "message": "Khi nào chúng tôi làm",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "Cập nhật",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "Dữ liệu nào của người dùng sẽ được thu thập?",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "Chính sách quyền Riêng Tư",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon是开源的。",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon 客户端使用了下列开源组件：",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows：",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android：",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "赛风是一个开源软件。您可以在GitHub上找到我们的代码。",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "下载",
@@ -1251,6 +1239,22 @@
         "message": "我们在何时这么做",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "更新",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "近期更新汇总",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "影响",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "解决方案",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "哪些用户数据将被收集",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "将会于2019-12-12T00:00起效。这项变更于一个月内有效。如果时间需要延长，我们会更新公告。",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "用户的活动数据保留在2020-04-10恢复到正常。",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19：隐私条款例外：用户IP意外保留",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "隐私政策",
@@ -1551,8 +1575,8 @@
         "message": "用户活动数据示例：一名用户在某一特定时间使用Comcast从纽约市接入，通过<code>youtube.com</code>传输100MB数据， 总共传输数据300MB。",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "我们认为用户活动数据是最敏感的数据种类。我们从不与第三方分享这类信息。我们将用户活动信息最多保存60天，然后我们会将数据整合并删除。",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1064,20 +1064,8 @@
         "description": ""
     },
     "open-source-para-1b": {
-        "message": "Psiphon is open source.",
-        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It should be kept short. It is a link to our Github project."
-    },
-    "open-source-para-2": {
-        "message": "Psiphon 客戶端使用了下列開源組件：",
-        "description": ""
-    },
-    "open-source-para-3-list-start": {
-        "message": "Windows：",
-        "description": "This refers to the Microsoft Windows operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Windows."
-    },
-    "open-source-para-4-list-start": {
-        "message": "Android：",
-        "description": "This refers to Google's Android operating system. It is followed by a list of 3rd party open source projects used in Psiphon for Android."
+        "message": "Psiphon is open source software. You can find our code on GitHub.",
+        "description": "Big, bold text the Open Source page indicating that Psiphon is open source software. It is a link to our Github project."
     },
     "page-keyword-download": {
         "message": "下載",
@@ -1251,6 +1239,22 @@
         "message": "我們何時這麼做",
         "description": ""
     },
+    "privacy-bulletin-entry-item-head-update": {
+        "message": "更新",
+        "description": "This is a header for text that is an update to an existing privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-what-happened": {
+        "message": "What happened",
+        "description": "This is a header for text that describes what happened to necessitate this privacy bulletin"
+    },
+    "privacy-bulletin-entry-item-head-impact": {
+        "message": "Impact",
+        "description": "This is a header for text that describes the impact of the privacy event that necessitated this privacy bulletin."
+    },
+    "privacy-bulletin-entry-item-head-resolution": {
+        "message": "Resolution",
+        "description": "This is a header for text that describes the resolution of the privacy event that necessitated this privacy bulletin."
+    },
     "privacy-bulletin-entry-item-head-what-data": {
         "message": "哪些用戶資料將被收集",
         "description": ""
@@ -1346,6 +1350,26 @@
     "privacy-bulletin-entry-4-when-doing": {
         "message": "This will be in effect starting 2019-12-12T00:00Z. It will be in effect for one month. We will update this bulletin if it needs to be extended beyond that.",
         "description": "A section of a privacy bulletin, indicating when the change or activity takes effect (if applicable)"
+    },
+    "privacy-bulletin-entry-4-update": {
+        "message": "User activity data retention was returned to normal by 2020-04-10.",
+        "description": "A section of a privacy bulletin, with an update to previous information."
+    },
+    "privacy-bulletin-entry-5-title": {
+        "message": "2020-06-19: Privacy exception: Accidental user IP retention",
+        "description": "Title for a privacy bulletin"
+    },
+    "privacy-bulletin-entry-5-what-happened": {
+        "message": "We use AWS S3 to host websites, client applications, and remote server lists. We discovered that logging had been enabled for many of our S3 resources since June 2015. These logs include IP addresses of users who accessed those resources.",
+        "description": "A section of a privacy bulletin, describing what happened to necessitate the bulletin"
+    },
+    "privacy-bulletin-entry-5-impact": {
+        "message": "We have no indication that any logs were obtained by any external party, so this is not a user data breach. However, it is a violation of our Privacy Policy.",
+        "description": "A section of a privacy bulletin, describing the impact of a privacy event"
+    },
+    "privacy-bulletin-entry-5-resolution": {
+        "message": "Logging has been disabled for user-accessible S3 buckets and all logs have been deleted. We are working on a system to keep track of privacy exceptions and issues, and investigating AWS resource auditing.",
+        "description": "A section of a privacy bulletin, describing the resolution of a privacy event"
     },
     "privacy-title": {
         "message": "隱私政策",
@@ -1551,8 +1575,8 @@
         "message": "An example of user activity data might be: At a certain time a user connected from New York City, using Comcast, and transferred 100MB from <code>youtube.com</code> and 300MB in total.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
-    "privacy-information-collected-vpndata-useractivity-para-4": {
-        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 60 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
+    "privacy-information-collected-vpndata-useractivity-para-4.1": {
+        "message": "We consider user activity data the most sensitive category of data. We never, ever share this data with third parties. We keep user activity data for at most 90 days, and then we aggregate it and delete it. Backups of that data are kept for a reasonable amount of time.",
         "description": "Paragraph text in the 'User Activity Data' definition subsection of the 'User Activity and VPN Data' section of the Privacy page."
     },
     "privacy-information-collected-vpndata-aggdata-subhead": {

--- a/docpad.coffee
+++ b/docpad.coffee
@@ -63,7 +63,8 @@ docpadConfig = {
 
     # Enabled languages
     # This is the order in which they will be displayed in the language picker
-    languages: ['en', 'fa', 'ar', 'zh', 'am', 'az', 'be', 'bn', 'bo', 'de', 'el', 'es', 'fa_AF', 'fi', 'fr', 'hr', 'id', 'kk', 'km', 'ko', 'ky', 'my', 'nb', 'nl', 'om', 'pt_BR', 'pt_PT', 'ru', 'tg', 'th', 'ti', 'tk', 'tr', 'uk', 'ur', 'uz', 'vi', 'zh_TW']
+    # NOTE: Do NOT remove languages unless you're sure they're not linked to from store descriptions, privacy policies, etc.
+    languages: ['en', 'fa', 'ar', 'zh', 'am', 'az', 'be', 'bn', 'bo', 'de', 'el', 'es', 'fa_AF', 'fi', 'fr', 'he', 'hi', 'hr', 'id', 'it', 'kk', 'km', 'ko', 'ky', 'my', 'nb', 'nl', 'om', 'pt_BR', 'pt_PT', 'ru', 'tg', 'th', 'ti', 'tk', 'tr', 'uk', 'ur', 'uz', 'vi', 'zh_TW']
     # Even if this array is modified during generation, the full list will always
     # be available in @all_languages.
 
@@ -85,8 +86,11 @@ docpadConfig = {
       fa_AF: './_locales/fa_AF/messages.json'
       fi: './_locales/fi/messages.json'
       fr: './_locales/fr/messages.json'
+      he: './_locales/he/messages.json'
+      hi: './_locales/hi/messages.json'
       hr: './_locales/hr/messages.json'
       id: './_locales/id/messages.json'
+      it: './_locales/it/messages.json'
       kk: './_locales/kk/messages.json'
       km: './_locales/km/messages.json'
       ko: './_locales/ko/messages.json'
@@ -251,10 +255,10 @@ docpadConfig = {
         title = @getTitle()
 
       if title
-        return "#{@tt 'psiphon'} | #{title}"
+        return "Psiphon | #{title}"
       else
         # if our document does not have it's own title, then we should just use the site's title
-        return "#{@tt 'psiphon'}"
+        return "Psiphon"
 
     # Get the prepared site/document description
     getPreparedDescription: ->
@@ -348,6 +352,8 @@ docpadConfig = {
         "fa_AF": "ﻑﺍﺮﺳی ﺩﺭی"
         "fi": "Suomi"
         "fr": "Français"
+        "he": "עברית"
+        "hi": "हिन्दी"
         "hr": "Hrvatski"
         "hu": "Magyar"
         "id": "Bahasa Indonesia"
@@ -357,8 +363,8 @@ docpadConfig = {
         "ko": "한국말"
         "ky": "Кыргызча"
         "my": "မြန်မာဘာသာ"
-        "nl": "Nederlands"
         "nb": "Norsk (bokmål)"
+        "nl": "Nederlands"
         "om": "Afaan Oromo"
         "pl": "Polski"
         "pt_BR": "Português (Brasil)"

--- a/i18n/transifex_pull.py
+++ b/i18n/transifex_pull.py
@@ -49,10 +49,11 @@ DEFAULT_LANGS = {
     'fa_AF': 'fa_AF',   # Persian (Afghanistan)
     'fi_FI': 'fi',      # Finnish
     'fr': 'fr',         # French
-    #'hi': 'hi',         # Hindi
+    'hi': 'hi',         # Hindi
+    'he': 'he',         # Hebrew
     'hr': 'hr',         # Croation
     'id': 'id',         # Indonesian
-    #'it': 'it',         # Italian
+    'it': 'it',         # Italian
     'kk': 'kk',         # Kazak
     'km': 'km',         # Khmer
     'ko': 'ko',         # Korean

--- a/src/layouts/_/pages/index.html.eco
+++ b/src/layouts/_/pages/index.html.eco
@@ -9,7 +9,7 @@ layout: _/default
   <div class="col-xs-8-center">
     <a href="<%= @getFullTranslatedURL '/download.html' %>">
       <img src="<%= @document.pathToRoot %>/images/hero/hero-large.png"
-           class="img-responsive center-block" alt="<%= @tt 'index-hero-alt' %>">
+           class="img-responsive center-block" alt="Psiphon">
       <h1 class="slabtext-container text-center" data-max-font-size="60">
         <span class="slabtext slab-main">
           <%= @tt 'index-hero-subtext' %>

--- a/src/partials/nav.html.eco
+++ b/src/partials/nav.html.eco
@@ -18,7 +18,7 @@
     </a>
     <a class="navbar-brand navbar-brand-name <%- @ifRTL 'navbar-right' %> <%- @ifRTL 'pull-right' %>" href="<%= @getFullTranslatedURL '/index.html' %>">
       <span>
-        <%= @tt 'psiphon' %>
+        Psiphon
       </span>
     </a>
   </div>
@@ -55,7 +55,7 @@
     </ul>
 
     <!-- LANGUAGE SWITCHER -->
-    
+
     <ul class="nav navbar-nav <%- @ifRTL 'navbar-left', 'navbar-right' %>">
       <li class="languages dropdown">
         <a class="dropdown-toggle" data-toggle="dropdown" href="<%= @getFullTranslatedURL '/nav/language.html' %>">
@@ -65,8 +65,8 @@
           <% for language in @all_languages : %>
           <li>
             <!-- If there's no translated equivalent to the current page, just link to the translated index page -->
-            
-            
+
+
             <a href="<%= @getFullTranslatedURL @document.url, language %>">
               <%= @languageLabel language %>
             </a>
@@ -75,7 +75,7 @@
         </ul>
       </li>
     </ul>
-    
+
     <!-- /LANGUAGE SWITCHER -->
 
   </div>


### PR DESCRIPTION
The languages added are not well-translated, but store descriptions were linking to them and getting 404, so we need them (and there's no real harm except a slower compile time).