### PR TITLE
Show App Store (but not Play Store) links on sponsored sites

### DIFF
--- a/src/layouts/_/pages/download.html.eco
+++ b/src/layouts/_/pages/download.html.eco
@@ -12,110 +12,108 @@ layout: _/page
 <div id="direct-priority-insert"></div>
 
 <!-- These need to be separate elements, or else we might show when we shouldn't. -->
-<div class="show-if-not-sponsored">
-  <div id="store" class="anchor-target">
-    <div class="row">
-      <div class="download-head">
-        <h2><%= @tt 'download-store-head' %></h2>
-      </div>
+<div id="store" class="anchor-target">
+  <div class="row">
+    <div class="download-head">
+      <h2><%= @tt 'download-store-head' %></h2>
     </div>
-
-    <!-- Psiphon Pro. Not dependent on presence of PsiphonAndroid.apk. -->
-    <div class="row download-item">
-      <div class="download-os-with-qr">
-        <a href="<%- @downloads.playstoreDevPage %>">
-          <img class="download-os-logo" src="<%= @relativeToRoot '/images/android/android-psiphon-logo.png' %>">
-          <img class="download-os-logo" src="<%= @relativeToRoot '/images/android/google-play-store.png' %>">
-        </a>
-      </div>
-      <div class="download-link-with-qr">
-        <h4>
-          <a href="<%- @downloads.playstoreDevPage %>" class="alert-link">
-            <%- @tt 'download-android-playstore-pro' %>
-          </a>
-        </h4>
-        <p>
-          <%- @tt 'download-android-playstore-pro-description' %>
-        </p>
-      </div>
-      <div class="download-qr">
-        <a href="<%- @downloads.playstoreDevPage %>">
-          <img class="img-responsive" src="<%= @relativeToRoot '/images/android/google-play-dev-page-qr.png' %>">
-        </a>
-      </div>
-    </div>
-
-    <!-- Psiphon VPN for iOS. -->
-    <div class="row download-item">
-      <div class="download-os-with-qr">
-        <a href="<%- @downloads.iosVpnAppStore %>">
-          <img class="download-os-logo" src="<%= @relativeToRoot '/images/ios/ios-vpn-logo.png' %>">
-          <img class="download-os-logo" src="<%= @relativeToRoot @ttURL '/images/ios/ios-app-store.svg' %>">
-        </a>
-      </div>
-      <div class="download-link-with-qr">
-        <h4>
-          <a href="<%- @downloads.iosVpnAppStore %>" class="alert-link">
-            <%- @tt 'download-ios-appstore-psiphon-vpn' %>
-          </a>
-        </h4>
-        <p>
-          <%- @tt 'download-ios-appstore-psiphon-vpn-description' %>
-        </p>
-      </div>
-      <div class="download-qr">
-        <a href="<%- @downloads.iosVpnAppStore %>">
-          <img class="img-responsive" src="<%= @relativeToRoot '/images/ios/psiphon-vpn-app-store-qr.png' %>">
-        </a>
-      </div>
-    </div>
-
-    <!-- Psiphon VPN for macOS -->
-    <div class="row download-item">
-      <div class="download-os">
-        <a href="<%- @downloads.macosVpnAppStore %>">
-          <img class="download-os-logo" src="<%= @relativeToRoot '/images/ios/ios-vpn-logo.png' %>">
-          <img class="download-os-logo" src="<%= @relativeToRoot @ttURL '/images/macos/mac-app-store.svg' %>">
-        </a>
-      </div>
-      <div class="download-link">
-        <h4>
-          <a href="<%- @downloads.macosVpnAppStore %>" class="alert-link">
-            <%- @tt 'download-macos-appstore-psiphon-vpn' %>
-          </a>
-        </h4>
-        <p>
-          <%- @tt 'download-macos-appstore-psiphon-vpn-description' %>
-        </p>
-      </div>
-    </div>
-
-    <!-- Psiphon Browser for iOS. -->
-    <div class="row download-item">
-      <div class="download-os-with-qr">
-        <a href="<%- @downloads.iosBrowserAppStore %>">
-          <img class="download-os-logo" src="<%= @relativeToRoot '/images/ios/ios-browser-logo.png' %>">
-          <img class="download-os-logo" src="<%= @relativeToRoot @ttURL '/images/ios/ios-app-store.svg' %>">
-        </a>
-      </div>
-      <div class="download-link-with-qr">
-        <h4>
-          <a href="<%- @downloads.iosBrowserAppStore %>" class="alert-link">
-            <%- @tt 'download-ios-appstore-psiphon-browser' %>
-          </a>
-        </h4>
-        <p>
-          <%- @tt 'download-ios-appstore-psiphon-browser-description' %>
-        </p>
-      </div>
-      <div class="download-qr">
-        <a href="<%- @downloads.iosBrowserAppStore %>">
-          <img class="img-responsive" src="<%= @relativeToRoot '/images/ios/psiphon-browser-app-store-qr.png' %>">
-        </a>
-      </div>
-    </div>
-
   </div>
+
+  <!-- Psiphon Pro. Not dependent on presence of PsiphonAndroid.apk. -->
+  <div class="row download-item show-if-not-sponsored">
+    <div class="download-os-with-qr">
+      <a href="<%- @downloads.playstoreDevPage %>">
+        <img class="download-os-logo" src="<%= @relativeToRoot '/images/android/android-psiphon-logo.png' %>">
+        <img class="download-os-logo" src="<%= @relativeToRoot '/images/android/google-play-store.png' %>">
+      </a>
+    </div>
+    <div class="download-link-with-qr">
+      <h4>
+        <a href="<%- @downloads.playstoreDevPage %>" class="alert-link">
+          <%- @tt 'download-android-playstore-pro' %>
+        </a>
+      </h4>
+      <p>
+        <%- @tt 'download-android-playstore-pro-description' %>
+      </p>
+    </div>
+    <div class="download-qr">
+      <a href="<%- @downloads.playstoreDevPage %>">
+        <img class="img-responsive" src="<%= @relativeToRoot '/images/android/google-play-dev-page-qr.png' %>">
+      </a>
+    </div>
+  </div>
+
+  <!-- Psiphon VPN for iOS. -->
+  <div class="row download-item">
+    <div class="download-os-with-qr">
+      <a href="<%- @downloads.iosVpnAppStore %>">
+        <img class="download-os-logo" src="<%= @relativeToRoot '/images/ios/ios-vpn-logo.png' %>">
+        <img class="download-os-logo" src="<%= @relativeToRoot @ttURL '/images/ios/ios-app-store.svg' %>">
+      </a>
+    </div>
+    <div class="download-link-with-qr">
+      <h4>
+        <a href="<%- @downloads.iosVpnAppStore %>" class="alert-link">
+          <%- @tt 'download-ios-appstore-psiphon-vpn' %>
+        </a>
+      </h4>
+      <p>
+        <%- @tt 'download-ios-appstore-psiphon-vpn-description' %>
+      </p>
+    </div>
+    <div class="download-qr">
+      <a href="<%- @downloads.iosVpnAppStore %>">
+        <img class="img-responsive" src="<%= @relativeToRoot '/images/ios/psiphon-vpn-app-store-qr.png' %>">
+      </a>
+    </div>
+  </div>
+
+  <!-- Psiphon VPN for macOS -->
+  <div class="row download-item">
+    <div class="download-os">
+      <a href="<%- @downloads.macosVpnAppStore %>">
+        <img class="download-os-logo" src="<%= @relativeToRoot '/images/ios/ios-vpn-logo.png' %>">
+        <img class="download-os-logo" src="<%= @relativeToRoot @ttURL '/images/macos/mac-app-store.svg' %>">
+      </a>
+    </div>
+    <div class="download-link">
+      <h4>
+        <a href="<%- @downloads.macosVpnAppStore %>" class="alert-link">
+          <%- @tt 'download-macos-appstore-psiphon-vpn' %>
+        </a>
+      </h4>
+      <p>
+        <%- @tt 'download-macos-appstore-psiphon-vpn-description' %>
+      </p>
+    </div>
+  </div>
+
+  <!-- Psiphon Browser for iOS. -->
+  <div class="row download-item">
+    <div class="download-os-with-qr">
+      <a href="<%- @downloads.iosBrowserAppStore %>">
+        <img class="download-os-logo" src="<%= @relativeToRoot '/images/ios/ios-browser-logo.png' %>">
+        <img class="download-os-logo" src="<%= @relativeToRoot @ttURL '/images/ios/ios-app-store.svg' %>">
+      </a>
+    </div>
+    <div class="download-link-with-qr">
+      <h4>
+        <a href="<%- @downloads.iosBrowserAppStore %>" class="alert-link">
+          <%- @tt 'download-ios-appstore-psiphon-browser' %>
+        </a>
+      </h4>
+      <p>
+        <%- @tt 'download-ios-appstore-psiphon-browser-description' %>
+      </p>
+    </div>
+    <div class="download-qr">
+      <a href="<%- @downloads.iosBrowserAppStore %>">
+        <img class="img-responsive" src="<%= @relativeToRoot '/images/ios/psiphon-browser-app-store-qr.png' %>">
+      </a>
+    </div>
+  </div>
+
 </div>
 
 <div id="direct" class="anchor-target">


### PR DESCRIPTION
We don't have a sideloading solution for iOS apps, so it doesn't make sense to hide the store links.